### PR TITLE
Release action: do not require workflow PAT

### DIFF
--- a/policy-release/action.yaml
+++ b/policy-release/action.yaml
@@ -12,8 +12,9 @@ inputs:
     required: true
     type: string
   workflow-pat:
-    required: true
+    required: false
     type: string
+    default: ""
   GITHUB_TOKEN:
     required: true
     type: string
@@ -81,7 +82,7 @@ runs:
         asset_content_type: application/wasm
     -
       name: Notify policy-hub
-      if: ${{ startsWith(github.ref, 'refs/tags/') && !(contains(github.ref, '-alpha') || contains(github.ref, '-beta') || contains(github.ref, '-rc')) }}
+      if: ${{ inputs.workflow-pat != "" && startsWith(github.ref, 'refs/tags/') && !(contains(github.ref, '-alpha') || contains(github.ref, '-beta') || contains(github.ref, '-rc')) }}
       uses: kubewarden/notify-policy-hub@main
       with:
         USERNAME: chimera-kube-bot


### PR DESCRIPTION
The workflow PAT is not going to be available for 3rd party policies (the ones created by users).

This is now optional. The notification step takes place only when a PAT is provided by the user.