### PR TITLE
Add reusable workflows for swift policies

### DIFF
--- a/.github/workflows/reusable-release-policy-swift.yml
+++ b/.github/workflows/reusable-release-policy-swift.yml
@@ -1,0 +1,56 @@
+name: Build and release a Kubewarden policy written in Swift
+
+on:
+  workflow_call:
+    inputs:
+      oci-target:
+        type: string
+        required: true
+    secrets:
+      workflow-pat:
+        description: "Github Personal Access Token (PAT) that can trigger workflow-dispatch"
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Install dependencies
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v1
+      -
+        name: install wasm-strip
+        run: |
+          export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true
+          sudo apt-get -q update
+          sudo apt-get -q install -y wabt binaryen
+      -
+        uses: actions/checkout@v2
+      -
+        name: Build release
+        uses: swiftwasm/swiftwasm-action@v5.3
+        with:
+          shell-action: swift build -c release --triple wasm32-unknown-wasi --build-path build
+      -
+        name: optimize policy
+        run: |
+          # need to fix file permissions because of some issue with Swift Foundation and filesystem
+          sudo chmod 777 build/wasm32-unknown-wasi/release/Policy.wasm
+          wasm-strip build/wasm32-unknown-wasi/release/Policy.wasm
+          wasm-opt -Os build/wasm32-unknown-wasi/release/Policy.wasm -o policy.wasm
+
+      -
+        name: Annotate Wasm module
+        run: |
+          kwctl annotate -m metadata.yml -o annotated-policy.wasm policy.wasm
+      -
+        name: Run e2e tests
+        run: |
+          make e2e-tests
+      -
+        name: Release
+        uses: kubewarden/github-actions/policy-release@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          oci-target: ${{ inputs.oci-target }}
+          workflow-pat: ${{ secrets.workflow-pat }}

--- a/.github/workflows/reusable-test-policy-swift.yml
+++ b/.github/workflows/reusable-test-policy-swift.yml
@@ -1,0 +1,17 @@
+name: Tests and linters
+
+on:
+  workflow_call:
+    inputs: {}
+    secrets: {}
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Run tests
+        uses: swiftwasm/swiftwasm-action@v5.3
+        with:
+          shell-action: carton test


### PR DESCRIPTION
These are lifted, with minor modifications, from the swift policies.

For successful runs, see:
- `main:`
   https://github.com/viccuad/pod-runtime-class-policy/actions/runs/1756243880
   https://github.com/viccuad/pod-runtime-class-policy/actions/runs/1756243890
- `tagged`:
   https://github.com/viccuad/pod-runtime-class-policy/actions/runs/1756531007: success until opening a PR against policy-hub, for which my token from the fork doesn't have perms. Yet this codepath is the same as the other, already accepted languages.