### PR TITLE
Add reusable workflows for Rego/OPA policies

### DIFF
--- a/.github/workflows/reusable-release-policy-rego.yml
+++ b/.github/workflows/reusable-release-policy-rego.yml
@@ -6,10 +6,6 @@ on:
       oci-target:
         type: string
         required: true
-      policy-type:
-        description: "Type of Rego policy; either 'gatekeeper' or 'opa'"
-        type: string
-        required: true
     secrets:
       workflow-pat:
         description: "Github Personal Access Token (PAT) that can trigger workflow-dispatch"

--- a/.github/workflows/reusable-release-policy-rego.yml
+++ b/.github/workflows/reusable-release-policy-rego.yml
@@ -1,0 +1,49 @@
+name: Build and release a Kubewarden policy written in Rego
+
+on:
+  workflow_call:
+    inputs:
+      oci-target:
+        type: string
+        required: true
+      policy-type:
+        description: "Type of Rego policy; either 'gatekeeper' or 'opa'"
+        type: string
+        required: true
+    secrets:
+      workflow-pat:
+        description: "Github Personal Access Token (PAT) that can trigger workflow-dispatch"
+        required: true
+        default: ""
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Install dependencies
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v1
+      -
+        name: Install opa
+        uses: kubewarden/github-actions/opa-installer@v1
+      -
+        uses: actions/checkout@v2
+      -
+        name: Build policy
+        run: |
+          make policy.wasm
+      -
+        name: Annotate policy
+        run: |
+          make annotated-policy.wasm
+      -
+        name: Run e2e tests
+        run: |
+          make e2e-tests
+      -
+        name: Release
+        uses: kubewarden/github-actions/policy-release@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          oci-target: ${{ inputs.oci-target }}
+          workflow-pat: ${{ secrets.workflow-pat }}

--- a/.github/workflows/reusable-test-policy-rego.yml
+++ b/.github/workflows/reusable-test-policy-rego.yml
@@ -1,0 +1,19 @@
+name: Tests and linters
+
+on:
+  workflow_call:
+    inputs: {}
+    secrets: {}
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        uses: actions/checkout@v2
+      -
+        name: Install opa
+        uses: kubewarden/github-actions/opa-installer@v1
+      -
+        name: Run unit tests
+        run: make test

--- a/opa-installer/action.yaml
+++ b/opa-installer/action.yaml
@@ -1,0 +1,26 @@
+name: 'opa-installer'
+description: 'Install opa and add it to PATH'
+branding:
+  icon: 'package'
+  color: 'blue'
+inputs:
+  opa-version:
+    description: 'opa release to be installed'
+    required: false
+    default: v0.32.0
+runs:
+  using: "composite"
+  steps:
+    - shell: bash
+      run: |
+        #!/bin/bash
+        set -e
+
+        INSTALL_DIR=$HOME/.opa
+
+        mkdir -p $INSTALL_DIR
+
+        curl -sL https://github.com/open-policy-agent/opa/releases/download/${{ inputs.opa-version }}/opa_linux_amd64_static -o $INSTALL_DIR/opa
+
+        chmod 755 $INSTALL_DIR/opa
+        echo $INSTALL_DIR >> $GITHUB_PATH


### PR DESCRIPTION
Add reusable workflows for both Rego and OPA policies. One can select the build process between rego or opa with `input.policy-type`.
Add Action to download and install `opa` binary.

Example of workflows:
- test: https://github.com/viccuad/disallow-service-loadbalancer-policy/runs/4979416788?check_suite_focus=true
- release: https://github.com/viccuad/disallow-service-loadbalancer-policy/runs/4979456627?check_suite_focus=true