### PR TITLE
Pass OCI target to policy hub.

### DIFF
--- a/policy-release/action.yaml
+++ b/policy-release/action.yaml
@@ -87,3 +87,4 @@ runs:
       with:
         USERNAME: chimera-kube-bot
         PAT: ${{ inputs.workflow-pat }}
+        OCITARGET: ${{ inputs.oci-target }}


### PR DESCRIPTION
To allow policy hub to verify the policies signatures, it's necessary to define the OCI target of the policy which the signature must be verified. This commit passes this data to it.


Depends on https://github.com/kubewarden/notify-policy-hub/pull/1
Related to https://github.com/kubewarden/policy-hub/pull/179