### PR TITLE
Go test action: use more recent version of Go

### DIFF
--- a/.github/workflows/reusable-test-policy-go.yml
+++ b/.github/workflows/reusable-test-policy-go.yml
@@ -14,7 +14,7 @@ jobs:
       - name: setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.15'
+          go-version: '1.17'
 
       - name: run Go unit tests
         run: make test


### PR DESCRIPTION
This is required to make some tests pass because they rely on things like `os.ReadFile` that have been introduced with Go 1.16.
