### PR TITLE
Tinygo 0.24.0 update.

### DIFF
--- a/policy-build-go/action.yaml
+++ b/policy-build-go/action.yaml
@@ -14,7 +14,7 @@ inputs:
     default: policy.wasm
   tinygo-version:
     required: true
-    default: 0.18.0
+    default: 0.24.0
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
## Description

Updates Tinygo version used to 0.20.0. Some policies are not able to
build due a error in the Tinygo version used:

Run tinygo build -o policy.wasm -target=wasi -no-debug .
error: could not read version from GOROOT (/opt/hostedtoolcache/go/1.17.11/x64): Invalid go version output:
// Code generated by go tool dist; DO NOT EDIT.

The error does not happen in version 0.20.0.

Fix https://github.com/kubewarden/safe-annotations-policy/issues/12
