### PR TITLE
Install kwctl v1.0.1

### DIFF
--- a/kwctl-installer/action.yaml
+++ b/kwctl-installer/action.yaml
@@ -7,7 +7,7 @@ inputs:
   KWCTL_VERSION:
     description: 'kwctl release to be installed'
     required: false
-    default: v0.3.1
+    default: v1.0.1
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
Updates the action used to install kwctl to install the latest version v1.0.1. This way, the latest changes regarding to the signatures verification will be in use avoiding issues when verifying keyless signatures. 
