### PR TITLE
SBOM generation for Go policies

### DIFF
--- a/policy-build-go/action.yaml
+++ b/policy-build-go/action.yaml
@@ -33,7 +33,37 @@ runs:
       run: |
         tinygo build -o ${{ inputs.wasm-binary }} -target=wasi -no-debug .
     -
+      name: Install SBOM generator tool
+      uses: kubewarden/github-actions/sbom-generator-installer@v1
+    -
+      name: Generate the SBOM files
+      shell: bash
+      run: |
+        spdx-sbom-generator -f json
+
+        # SBOM files should have "sbom" in the name due the CLO monitor
+        # https://clomonitor.io/docs/topics/checks/#software-bill-of-materials-sbom
+        mv bom-go-mod.json policy-sbom.spdx.json
+    -
       name: Annotate Wasm module
       shell: bash
       run: |
         kwctl annotate -m ${{ inputs.metadata-file }} -o annotated-policy.wasm ${{ inputs.wasm-binary }}
+    -
+      name: Sign BOM file
+      shell: bash
+      run: |
+        cosign sign-blob --output-certificate policy-sbom.spdx.cert \
+          --output-signature policy-sbom.spdx.sig \
+          policy-sbom.spdx.json
+      env:
+        COSIGN_EXPERIMENTAL: 1
+    -
+      name:  Upload policy SBOM files
+      uses: actions/upload-artifact@v2
+      with:
+        name: policy-sbom
+        path: |
+          policy-sbom.spdx.json
+          policy-sbom.spdx.cert
+          policy-sbom.spdx.sig


### PR DESCRIPTION
## Description

Updates the action used to build the Go policies adding steps to generate the SBOM file using the SPDX format.

Fix https://github.com/kubewarden/go-policy-template/issues/30
