### PR TITLE
Add 1 agent node to k3d cluster

### DIFF
--- a/setup-kubewarden-cluster-action/action.yaml
+++ b/setup-kubewarden-cluster-action/action.yaml
@@ -38,6 +38,11 @@ inputs:
     required: false
     type: string
     default: "kubewarden-test-cluster"
+  cluster-args:
+    description: "K3d cluster arguments"
+    required: false
+    type: string
+    default: "--agents 1"
 
 runs:
   using: "composite"
@@ -59,6 +64,7 @@ runs:
       name: "Create Kubernetes cluster"
       with:
         cluster-name: ${{ inputs.cluster-name }}
+        args: ${{ inputs.cluster-args }}
     -
       name: "Download Kubewarden controller container image artifact"
       if: ${{ inputs.controller-container-image-artifact != '' }}


### PR DESCRIPTION
Cluster is deployed by default with 1 server 0 agent nodes.
This allows to pass k3d arguments, setting default to 1 agent node.