### PR TITLE
chore(deps): update tinygo version

### DIFF
--- a/policy-build-go/action.yaml
+++ b/policy-build-go/action.yaml
@@ -14,7 +14,7 @@ inputs:
     default: policy.wasm
   tinygo-version:
     required: true
-    default: 0.24.0
+    default: 0.26.0
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
Use latest version of tinygo when building our Go-based policies.