### PR TITLE
Use newer k3s version to prevent EOF bug

### DIFF
--- a/setup-kubewarden-cluster-action/action.yaml
+++ b/setup-kubewarden-cluster-action/action.yaml
@@ -42,7 +42,7 @@ inputs:
     description: "K3d cluster arguments"
     required: false
     type: string
-    default: "--agents 1"
+    default: "--agents 1 --image rancher/k3s:v1.24.9-k3s2"
 
 runs:
   using: "composite"


### PR DESCRIPTION
Bug description https://github.com/k3s-io/k3s/issues/5835

It should fix EOF errors [e2e tests](https://github.com/kubewarden/kubewarden-controller/actions/workflows/e2e-tests.yml):
```
# Error: UPGRADE FAILED: cannot patch "no-privilege-escalation" with kind ClusterAdmissionPolicy: Internal error occurred: failed calling webhook "vclusteradmissionpolicy.kb.io": failed to call webhook: Post "https://kubewarden-controller-webhook-service.kubewarden.svc:443/validate-policies-kubewarden-io-v1-clusteradmissionpolicy?timeout=10s": EOF

# Error: UPGRADE FAILED: cannot patch "kubewarden-controller-serving-cert" with kind Certificate: Internal error occurred: failed calling webhook "webhook.cert-manager.io": failed to call webhook: Post "https://cert-manager-webhook.cert-manager.svc:443/validate?timeout=10s": EOF

# Error from server (InternalError): Internal error occurred: failed calling webhook "clusterwide-privileged-pods.kubewarden.admission": failed to call webhook: Post "https://policy-server-default.kubewarden.svc:8443/validate/clusterwide-privileged-pods?timeout=10s": EOF
```