### PR TITLE
deps: Pin cosign to 1.*

### DIFF
--- a/policy-build-go/action.yaml
+++ b/policy-build-go/action.yaml
@@ -33,9 +33,6 @@ runs:
       run: |
         tinygo build -o ${{ inputs.wasm-binary }} -target=wasi -no-debug .
     -
-      name: Install SBOM generator tool
-      uses: kubewarden/github-actions/sbom-generator-installer@v1
-    -
       name: Generate the SBOM files
       shell: bash
       run: |

--- a/policy-build-rust/action.yaml
+++ b/policy-build-rust/action.yaml
@@ -36,9 +36,6 @@ runs:
       run: |
         kwctl annotate -m ${{ inputs.metadata-file }} -o annotated-policy.wasm ${{ inputs.input-wasm }}
     -
-      name: Install SBOM generator tool
-      uses: kubewarden/github-actions/sbom-generator-installer@v1
-    -
       name: Generate the SBOM files
       shell: bash
       run: |
@@ -47,9 +44,6 @@ runs:
         # SBOM files should have "sbom" in the name due the CLO monitor
         # https://clomonitor.io/docs/topics/checks/#software-bill-of-materials-sbom
         mv bom-cargo.json policy-sbom.spdx.json
-    -
-      name: Install cosign
-      uses: sigstore/cosign-installer@main
     -
       name: Sign BOM file
       shell: bash

--- a/policy-gh-action-dependencies/action.yaml
+++ b/policy-gh-action-dependencies/action.yaml
@@ -8,7 +8,7 @@ runs:
   steps:
     -
       name: Install cosign
-      uses: sigstore/cosign-installer@main
+      uses: sigstore/cosign-installer@v2.8.1
     -
       name: Install kwctl
       uses: kubewarden/github-actions/kwctl-installer@v1

--- a/policy-gh-action-dependencies/action.yaml
+++ b/policy-gh-action-dependencies/action.yaml
@@ -17,3 +17,6 @@ runs:
       uses: mig4/setup-bats@v1
       with:
         bats-version: 1.5.0
+    -
+      name: Install SBOM generator tool
+      uses: kubewarden/github-actions/sbom-generator-installer@v1


### PR DESCRIPTION
## Description

Cosign 2.0 was [released last week](https://blog.sigstore.dev/cosign-2-0-released/) (yay!) but, as expected because semver, it's not backwards compatible (nay!).

Pin cosign-installer GHA so it downloads cosign 1.*.
Latest [cosign-installer downloads cosign 2.*](https://github.com/sigstore/cosign-installer/releases/tag/v3.0.0).

## Test

I know this works, because I needed to do this to release my own unrelated viccuad/kwctl:
https://github.com/viccuad/kwctl/actions/runs/4315689467/jobs/7530608694

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
