### PR TITLE
Revert "chore(deps): update sigstore/cosign-installer action to v3"

### DIFF
--- a/policy-gh-action-dependencies/action.yaml
+++ b/policy-gh-action-dependencies/action.yaml
@@ -8,7 +8,7 @@ runs:
   steps:
     -
       name: Install cosign
-      uses: sigstore/cosign-installer@v3.0.1
+      uses: sigstore/cosign-installer@v2.8.1
     -
       name: Install kwctl
       uses: kubewarden/github-actions/kwctl-installer@v1


### PR DESCRIPTION
Reverts kubewarden/github-actions#50

We need to pin `cosign` to 1.*, as there are backwards compat changes.