### PR TITLE
fix: Correctly check artifacthub for policies that use tags

### DIFF
--- a/.github/workflows/reusable-release-policy-assemblyscript.yml
+++ b/.github/workflows/reusable-release-policy-assemblyscript.yml
@@ -6,6 +6,11 @@ on:
       oci-target:
         type: string
         required: true
+      artifacthub:
+        description: 'check artifacthub-pkg.yml for submission to ArtifactHub'
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   release:
@@ -16,6 +21,20 @@ jobs:
       -
         name: Install dependencies
         uses: kubewarden/github-actions/policy-gh-action-dependencies@v2
+      -
+        uses: actions/checkout@v3
+      -
+        id: calculate-version
+        if: ${{ inputs.artifacthub }}
+        # obtain latest tag. Here it must be the current release tag
+        run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
+        shell: bash
+      -
+        name: Check that artifacthub-pkg.yml is up-to-date
+        if: ${{ inputs.artifacthub }}
+        uses: kubewarden/github-actions/check-artifacthub@v2
+        with:
+          version: ${{ steps.calculate-version.outputs.version }}
       -
         name: Setup node
         uses: actions/setup-node@v3

--- a/.github/workflows/reusable-release-policy-assemblyscript.yml
+++ b/.github/workflows/reusable-release-policy-assemblyscript.yml
@@ -23,6 +23,9 @@ jobs:
         uses: kubewarden/github-actions/policy-gh-action-dependencies@v2
       -
         uses: actions/checkout@v3
+        with:
+          # until https://github.com/actions/checkout/pull/579 is released
+          fetch-depth: 0
       -
         id: calculate-version
         if: ${{ inputs.artifacthub }}

--- a/.github/workflows/reusable-release-policy-go.yml
+++ b/.github/workflows/reusable-release-policy-go.yml
@@ -6,6 +6,11 @@ on:
       oci-target:
         type: string
         required: true
+      artifacthub:
+        description: 'check artifacthub-pkg.yml for submission to ArtifactHub'
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   release:
@@ -14,6 +19,20 @@ jobs:
       -
         name: Install dependencies
         uses: kubewarden/github-actions/policy-gh-action-dependencies@v2
+      -
+        uses: actions/checkout@v3
+      -
+        id: calculate-version
+        if: ${{ inputs.artifacthub }}
+        # obtain latest tag. Here it must be the current release tag
+        run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
+        shell: bash
+      -
+        name: Check that artifacthub-pkg.yml is up-to-date
+        if: ${{ inputs.artifacthub }}
+        uses: kubewarden/github-actions/check-artifacthub@v2
+        with:
+          version: ${{ steps.calculate-version.outputs.version }}
       -
         name: Build and annotate policy
         uses: kubewarden/github-actions/policy-build-go@v2

--- a/.github/workflows/reusable-release-policy-go.yml
+++ b/.github/workflows/reusable-release-policy-go.yml
@@ -21,6 +21,9 @@ jobs:
         uses: kubewarden/github-actions/policy-gh-action-dependencies@v2
       -
         uses: actions/checkout@v3
+        with:
+          # until https://github.com/actions/checkout/pull/579 is released
+          fetch-depth: 0
       -
         id: calculate-version
         if: ${{ inputs.artifacthub }}

--- a/.github/workflows/reusable-release-policy-rego.yml
+++ b/.github/workflows/reusable-release-policy-rego.yml
@@ -21,6 +21,9 @@ jobs:
         uses: kubewarden/github-actions/policy-gh-action-dependencies@v2
       -
         uses: actions/checkout@v3
+        with:
+          # until https://github.com/actions/checkout/pull/579 is released
+          fetch-depth: 0
       -
         id: calculate-version
         if: ${{ inputs.artifacthub }}

--- a/.github/workflows/reusable-release-policy-rego.yml
+++ b/.github/workflows/reusable-release-policy-rego.yml
@@ -6,6 +6,11 @@ on:
       oci-target:
         type: string
         required: true
+      artifacthub:
+        description: 'check artifacthub-pkg.yml for submission to ArtifactHub'
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   release:
@@ -14,6 +19,20 @@ jobs:
       -
         name: Install dependencies
         uses: kubewarden/github-actions/policy-gh-action-dependencies@v2
+      -
+        uses: actions/checkout@v3
+      -
+        id: calculate-version
+        if: ${{ inputs.artifacthub }}
+        # obtain latest tag. Here it must be the current release tag
+        run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
+        shell: bash
+      -
+        name: Check that artifacthub-pkg.yml is up-to-date
+        if: ${{ inputs.artifacthub }}
+        uses: kubewarden/github-actions/check-artifacthub@v2
+        with:
+          version: ${{ steps.calculate-version.outputs.version }}
       -
         name: Install opa
         uses: kubewarden/github-actions/opa-installer@v2

--- a/.github/workflows/reusable-release-policy-rust.yml
+++ b/.github/workflows/reusable-release-policy-rust.yml
@@ -21,6 +21,9 @@ jobs:
         uses: kubewarden/github-actions/policy-gh-action-dependencies@v2
       -
         uses: actions/checkout@v3
+        with:
+          # until https://github.com/actions/checkout/pull/579 is released
+          fetch-depth: 0
       -
         id: calculate-version
         if: ${{ inputs.artifacthub }}

--- a/.github/workflows/reusable-release-policy-rust.yml
+++ b/.github/workflows/reusable-release-policy-rust.yml
@@ -6,6 +6,11 @@ on:
       oci-target:
         type: string
         required: true
+      artifacthub:
+        description: 'check artifacthub-pkg.yml for submission to ArtifactHub'
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   release:
@@ -14,6 +19,20 @@ jobs:
       -
         name: Install dependencies
         uses: kubewarden/github-actions/policy-gh-action-dependencies@v2
+      -
+        uses: actions/checkout@v3
+      -
+        id: calculate-version
+        if: ${{ inputs.artifacthub }}
+        # obtain latest tag. Here it must be the current release tag
+        run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
+        shell: bash
+      -
+        name: Check that artifacthub-pkg.yml is up-to-date
+        if: ${{ inputs.artifacthub }}
+        uses: kubewarden/github-actions/check-artifacthub@v2
+        with:
+          version: ${{ steps.calculate-version.outputs.version }}
       -
         name: Build and annotate policy
         uses: kubewarden/github-actions/policy-build-rust@v2

--- a/.github/workflows/reusable-release-policy-swift.yml
+++ b/.github/workflows/reusable-release-policy-swift.yml
@@ -6,6 +6,11 @@ on:
       oci-target:
         type: string
         required: true
+      artifacthub:
+        description: 'check artifacthub-pkg.yml for submission to ArtifactHub'
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   release:
@@ -15,13 +20,25 @@ jobs:
         name: Install dependencies
         uses: kubewarden/github-actions/policy-gh-action-dependencies@v2
       -
+        uses: actions/checkout@v3
+      -
+        id: calculate-version
+        if: ${{ inputs.artifacthub }}
+        # obtain latest tag. Here it must be the current release tag
+        run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
+        shell: bash
+      -
+        name: Check that artifacthub-pkg.yml is up-to-date
+        if: ${{ inputs.artifacthub }}
+        uses: kubewarden/github-actions/check-artifacthub@v2
+        with:
+          version: ${{ steps.calculate-version.outputs.version }}
+      -
         name: install wasm-strip
         run: |
           export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true
           sudo apt-get -q update
           sudo apt-get -q install -y wabt binaryen
-      -
-        uses: actions/checkout@v3
       -
         name: Build release
         uses: swiftwasm/swiftwasm-action@v5.7

--- a/.github/workflows/reusable-release-policy-swift.yml
+++ b/.github/workflows/reusable-release-policy-swift.yml
@@ -21,6 +21,9 @@ jobs:
         uses: kubewarden/github-actions/policy-gh-action-dependencies@v2
       -
         uses: actions/checkout@v3
+        with:
+          # until https://github.com/actions/checkout/pull/579 is released
+          fetch-depth: 0
       -
         id: calculate-version
         if: ${{ inputs.artifacthub }}

--- a/.github/workflows/reusable-test-policy-assemblyscript.yml
+++ b/.github/workflows/reusable-test-policy-assemblyscript.yml
@@ -41,7 +41,7 @@ jobs:
         uses: kubewarden/github-actions/kwctl-installer@v2
       -
         id: calculate-version
-        run: echo "version=$(echo ${{ github.ref_name }} | sed 's/v//')" >> $GITHUB_OUTPUT
+        run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
       -
         name: Check that artifacthub-pkg.yml is up-to-date

--- a/.github/workflows/reusable-test-policy-assemblyscript.yml
+++ b/.github/workflows/reusable-test-policy-assemblyscript.yml
@@ -36,6 +36,9 @@ jobs:
     steps:
       -
         uses: actions/checkout@v3
+        with:
+          # until https://github.com/actions/checkout/pull/579 is released
+          fetch-depth: 0
       -
         name: Install kwctl
         uses: kubewarden/github-actions/kwctl-installer@v2

--- a/.github/workflows/reusable-test-policy-assemblyscript.yml
+++ b/.github/workflows/reusable-test-policy-assemblyscript.yml
@@ -48,3 +48,4 @@ jobs:
         uses: kubewarden/github-actions/check-artifacthub@v2
         with:
           version: ${{ steps.calculate-version.outputs.version }}
+          check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then

--- a/.github/workflows/reusable-test-policy-go.yml
+++ b/.github/workflows/reusable-test-policy-go.yml
@@ -34,7 +34,7 @@ jobs:
         uses: kubewarden/github-actions/kwctl-installer@v2
       -
         id: calculate-version
-        run: echo "version=$(echo ${{ github.ref_name }} | sed 's/v//')" >> $GITHUB_OUTPUT
+        run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
       -
         name: Check that artifacthub-pkg.yml is up-to-date

--- a/.github/workflows/reusable-test-policy-go.yml
+++ b/.github/workflows/reusable-test-policy-go.yml
@@ -29,6 +29,9 @@ jobs:
     steps:
       -
         uses: actions/checkout@v3
+        with:
+          # until https://github.com/actions/checkout/pull/579 is released
+          fetch-depth: 0
       -
         name: Install kwctl
         uses: kubewarden/github-actions/kwctl-installer@v2

--- a/.github/workflows/reusable-test-policy-go.yml
+++ b/.github/workflows/reusable-test-policy-go.yml
@@ -41,3 +41,4 @@ jobs:
         uses: kubewarden/github-actions/check-artifacthub@v2
         with:
           version: ${{ steps.calculate-version.outputs.version }}
+          check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then

--- a/.github/workflows/reusable-test-policy-rego.yml
+++ b/.github/workflows/reusable-test-policy-rego.yml
@@ -40,3 +40,4 @@ jobs:
         uses: kubewarden/github-actions/check-artifacthub@v2
         with:
           version: ${{ steps.calculate-version.outputs.version }}
+          check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then

--- a/.github/workflows/reusable-test-policy-rego.yml
+++ b/.github/workflows/reusable-test-policy-rego.yml
@@ -28,6 +28,9 @@ jobs:
     steps:
       -
         uses: actions/checkout@v3
+        with:
+          # until https://github.com/actions/checkout/pull/579 is released
+          fetch-depth: 0
       -
         name: Install kwctl
         uses: kubewarden/github-actions/kwctl-installer@v2

--- a/.github/workflows/reusable-test-policy-rego.yml
+++ b/.github/workflows/reusable-test-policy-rego.yml
@@ -33,7 +33,7 @@ jobs:
         uses: kubewarden/github-actions/kwctl-installer@v2
       -
         id: calculate-version
-        run: echo "version=$(echo ${{ github.ref_name }} | sed 's/v//')" >> $GITHUB_OUTPUT
+        run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
       -
         name: Check that artifacthub-pkg.yml is up-to-date

--- a/.github/workflows/reusable-test-policy-rust.yml
+++ b/.github/workflows/reusable-test-policy-rust.yml
@@ -32,9 +32,9 @@ jobs:
     steps:
       -
         uses: actions/checkout@v3
-      -
-        name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v2
+        with:
+          # until https://github.com/actions/checkout/pull/579 is released
+          fetch-depth: 0
       -
         id: calculate-version
         run: echo "version=$(sed  -n 's,^version = \"\(.*\)\",\1,p' Cargo.toml)" >> $GITHUB_OUTPUT

--- a/.github/workflows/reusable-test-policy-swift.yml
+++ b/.github/workflows/reusable-test-policy-swift.yml
@@ -38,3 +38,4 @@ jobs:
         uses: kubewarden/github-actions/check-artifacthub@v2
         with:
           version: ${{ steps.calculate-version.outputs.version }}
+          check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then

--- a/.github/workflows/reusable-test-policy-swift.yml
+++ b/.github/workflows/reusable-test-policy-swift.yml
@@ -26,6 +26,9 @@ jobs:
     steps:
       -
         uses: actions/checkout@v3
+        with:
+          # until https://github.com/actions/checkout/pull/579 is released
+          fetch-depth: 0
       -
         name: Install kwctl
         uses: kubewarden/github-actions/kwctl-installer@v2

--- a/.github/workflows/reusable-test-policy-swift.yml
+++ b/.github/workflows/reusable-test-policy-swift.yml
@@ -31,7 +31,7 @@ jobs:
         uses: kubewarden/github-actions/kwctl-installer@v2
       -
         id: calculate-version
-        run: echo "version=$(echo ${{ github.ref_name }} | sed 's/v//')" >> $GITHUB_OUTPUT
+        run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
       -
         name: Check that artifacthub-pkg.yml is up-to-date

--- a/check-artifacthub/action.yaml
+++ b/check-artifacthub/action.yaml
@@ -8,6 +8,10 @@ inputs:
     description: 'version string to use in artifacthub-plg.yml'
     required: true
     type: string
+  check_version:
+    description: 'check version string in comparison'
+    default: true
+    type: bool
 runs:
   using: "composite"
   steps:
@@ -20,7 +24,20 @@ runs:
       run: |
         rm artifacthub-pkg.yml # force recreation of file
         make artifacthub-pkg.yml VERSION=${{ inputs.version }}
-        git diff \
-          --ignore-matching-lines '^createdAt'\
-          --exit-code artifacthub-pkg.yml || \
-          (echo; echo "There are differences in artifacthub-pkg.yml that have to be checked in"; exit 1)
+        # ignore createdAt: if there's a new file it will always be newer
+        if ${{ inputs.check_version }}; then
+          # check version: version must match a known version (from Cargo.toml,
+          # or a present git tag)
+          git diff \
+            --ignore-matching-lines '^createdAt'\
+            --exit-code artifacthub-pkg.yml || \
+            (echo; echo "There are differences in artifacthub-pkg.yml that have to be checked in.\nIf version is outdated, run \`make --always-make artifacthub-pkg.yml VERSION=<new tag>\`"; exit 1)
+        else
+          # don't check_version: version must match a future tag that hasn't been
+          # created yet, so let's not check for it
+          git diff \
+            --ignore-matching-lines '^createdAt'\
+            --ignore-matching-lines '^version'\
+            --exit-code artifacthub-pkg.yml || \
+            (echo; echo "There are differences in artifacthub-pkg.yml that have to be checked in"; exit 1)
+        fi


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Relates to https://github.com/kubewarden/kubewarden-controller/issues/389.

Obtain tag string correctly
For reusable-test-policy-* jobs:
  check artifacthub-pkg.yml, but ignore the version field, as the tag is not yet created.
For reusable-release-policy-* jobs:
  check artifacthub-pkg.yml, and check the version field, as the tag is created.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

- On test, example of success, as we can't check the version yet:
  https://github.com/viccuad/hostpaths-psp-policy/actions/runs/4436667835
  https://github.com/viccuad/hostpaths-psp-policy/actions/runs/4436667844
- On release, example of failure because they forgot to bump the version in all artifacthub-pkg.yml:
  https://github.com/viccuad/hostpaths-psp-policy/actions/runs/4436678314/jobs/7785403964
  This is fixed by committing the result of:
  `touch metadata.yml && make artifacthub-pkg.yml VERSION=0.1.8`
  

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

Needing to manually do `make --always-make artifacthub-pkg.yml VERSION=0.1.8` is not very discoverable for users. At least it is included in the error string though.
