### PR TITLE
fix: Ignore artifacthub fields related with `version`

### DIFF
--- a/.github/workflows/reusable-test-policy-rust.yml
+++ b/.github/workflows/reusable-test-policy-rust.yml
@@ -36,6 +36,9 @@ jobs:
           # until https://github.com/actions/checkout/pull/579 is released
           fetch-depth: 0
       -
+        name: Install kwctl
+        uses: kubewarden/github-actions/kwctl-installer@v2
+      -
         id: calculate-version
         run: echo "version=$(sed  -n 's,^version = \"\(.*\)\",\1,p' Cargo.toml)" >> $GITHUB_OUTPUT
         shell: bash

--- a/check-artifacthub/action.yaml
+++ b/check-artifacthub/action.yaml
@@ -38,6 +38,8 @@ runs:
           git diff \
             --ignore-matching-lines '^createdAt'\
             --ignore-matching-lines '^version'\
+            --ignore-matching-lines '^( )*image: *'\
+            --ignore-matching-lines 'policy.wasm$'\
             --exit-code artifacthub-pkg.yml || \
             (echo; echo "There are differences in artifacthub-pkg.yml that have to be checked in"; exit 1)
         fi


### PR DESCRIPTION
## Description

Relates to https://github.com/kubewarden/kubewarden-controller/issues/389.

Bumping `version` in artifacthub-pkg.yml not only changes `version`, but `containerImages[].image` and `links[].url`:

```
containersImages:
 - name: policy
   image: ghcr.io/kubewarden/policies/hostpaths-psp:v0.1.8
links:
 - name: policy
   url: https://github.com/kubewarden/hostpaths-psp-policy/releases/download/v0.1.8/policy.wasm
```

Naively skip those then. It's not perfect, but it's something.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

Locally. What's the worse that can happen. It's already broken.

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
- [ ] TODO tag in main as v2.0.2 & v2.