### PR TITLE
fix: Ignore lines with `ghcr.io` if not checking version

### DIFF
--- a/check-artifacthub/action.yaml
+++ b/check-artifacthub/action.yaml
@@ -40,6 +40,7 @@ runs:
             --ignore-matching-lines '^version'\
             --ignore-matching-lines '^( )*image: *'\
             --ignore-matching-lines 'policy.wasm$'\
+            --ignore-matching-lines '.*ghcr.io.*'\
             --exit-code artifacthub-pkg.yml || \
             (echo; echo "There are differences in artifacthub-pkg.yml that have to be checked in"; exit 1)
         fi


### PR DESCRIPTION


## Description

This will ignore the `install` field line containing the OCI URL of the policy.

Relates to https://github.com/kubewarden/ingress-policy/pull/26.

## Test

Tested locally.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
