### PR TITLE
chore: Drop `v2` tags, start consuming full semvers

### DIFF
--- a/.github/workflows/reusable-release-policy-assemblyscript.yml
+++ b/.github/workflows/reusable-release-policy-assemblyscript.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       -
         name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v2
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v2.0.4
       -
         uses: actions/checkout@v3
         with:
@@ -35,7 +35,7 @@ jobs:
       -
         name: Check that artifacthub-pkg.yml is up-to-date
         if: ${{ inputs.artifacthub }}
-        uses: kubewarden/github-actions/check-artifacthub@v2
+        uses: kubewarden/github-actions/check-artifacthub@v2.0.4
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       -
@@ -66,7 +66,7 @@ jobs:
           make e2e-tests
       -
         name: Release
-        uses: kubewarden/github-actions/policy-release@v2
+        uses: kubewarden/github-actions/policy-release@v2.0.4
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}

--- a/.github/workflows/reusable-release-policy-assemblyscript.yml
+++ b/.github/workflows/reusable-release-policy-assemblyscript.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       -
         name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v2.0.4
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v2.0.5
       -
         uses: actions/checkout@v3
         with:
@@ -35,7 +35,7 @@ jobs:
       -
         name: Check that artifacthub-pkg.yml is up-to-date
         if: ${{ inputs.artifacthub }}
-        uses: kubewarden/github-actions/check-artifacthub@v2.0.4
+        uses: kubewarden/github-actions/check-artifacthub@v2.0.5
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       -
@@ -66,7 +66,7 @@ jobs:
           make e2e-tests
       -
         name: Release
-        uses: kubewarden/github-actions/policy-release@v2.0.4
+        uses: kubewarden/github-actions/policy-release@v2.0.5
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}

--- a/.github/workflows/reusable-release-policy-go.yml
+++ b/.github/workflows/reusable-release-policy-go.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       -
         name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v2.0.4
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v2.0.5
       -
         uses: actions/checkout@v3
         with:
@@ -33,19 +33,19 @@ jobs:
       -
         name: Check that artifacthub-pkg.yml is up-to-date
         if: ${{ inputs.artifacthub }}
-        uses: kubewarden/github-actions/check-artifacthub@v2.0.4
+        uses: kubewarden/github-actions/check-artifacthub@v2.0.5
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       -
         name: Build and annotate policy
-        uses: kubewarden/github-actions/policy-build-go@v2.0.4
+        uses: kubewarden/github-actions/policy-build-go@v2.0.5
       -
         name: Run e2e tests
         run: |
           make e2e-tests
       -
         name: Release
-        uses: kubewarden/github-actions/policy-release@v2.0.4
+        uses: kubewarden/github-actions/policy-release@v2.0.5
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}

--- a/.github/workflows/reusable-release-policy-go.yml
+++ b/.github/workflows/reusable-release-policy-go.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       -
         name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v2
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v2.0.4
       -
         uses: actions/checkout@v3
         with:
@@ -33,19 +33,19 @@ jobs:
       -
         name: Check that artifacthub-pkg.yml is up-to-date
         if: ${{ inputs.artifacthub }}
-        uses: kubewarden/github-actions/check-artifacthub@v2
+        uses: kubewarden/github-actions/check-artifacthub@v2.0.4
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       -
         name: Build and annotate policy
-        uses: kubewarden/github-actions/policy-build-go@v2
+        uses: kubewarden/github-actions/policy-build-go@v2.0.4
       -
         name: Run e2e tests
         run: |
           make e2e-tests
       -
         name: Release
-        uses: kubewarden/github-actions/policy-release@v2
+        uses: kubewarden/github-actions/policy-release@v2.0.4
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}

--- a/.github/workflows/reusable-release-policy-rego.yml
+++ b/.github/workflows/reusable-release-policy-rego.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       -
         name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v2
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v2.0.4
       -
         uses: actions/checkout@v3
         with:
@@ -33,12 +33,12 @@ jobs:
       -
         name: Check that artifacthub-pkg.yml is up-to-date
         if: ${{ inputs.artifacthub }}
-        uses: kubewarden/github-actions/check-artifacthub@v2
+        uses: kubewarden/github-actions/check-artifacthub@v2.0.4
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       -
         name: Install opa
-        uses: kubewarden/github-actions/opa-installer@v2
+        uses: kubewarden/github-actions/opa-installer@v2.0.4
       -
         uses: actions/checkout@v3
       -
@@ -55,7 +55,7 @@ jobs:
           make e2e-tests
       -
         name: Release
-        uses: kubewarden/github-actions/policy-release@v2
+        uses: kubewarden/github-actions/policy-release@v2.0.4
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}

--- a/.github/workflows/reusable-release-policy-rego.yml
+++ b/.github/workflows/reusable-release-policy-rego.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       -
         name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v2.0.4
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v2.0.5
       -
         uses: actions/checkout@v3
         with:
@@ -33,12 +33,12 @@ jobs:
       -
         name: Check that artifacthub-pkg.yml is up-to-date
         if: ${{ inputs.artifacthub }}
-        uses: kubewarden/github-actions/check-artifacthub@v2.0.4
+        uses: kubewarden/github-actions/check-artifacthub@v2.0.5
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       -
         name: Install opa
-        uses: kubewarden/github-actions/opa-installer@v2.0.4
+        uses: kubewarden/github-actions/opa-installer@v2.0.5
       -
         uses: actions/checkout@v3
       -
@@ -55,7 +55,7 @@ jobs:
           make e2e-tests
       -
         name: Release
-        uses: kubewarden/github-actions/policy-release@v2.0.4
+        uses: kubewarden/github-actions/policy-release@v2.0.5
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}

--- a/.github/workflows/reusable-release-policy-rust.yml
+++ b/.github/workflows/reusable-release-policy-rust.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       -
         name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v2.0.4
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v2.0.5
       -
         uses: actions/checkout@v3
         with:
@@ -33,19 +33,19 @@ jobs:
       -
         name: Check that artifacthub-pkg.yml is up-to-date
         if: ${{ inputs.artifacthub }}
-        uses: kubewarden/github-actions/check-artifacthub@v2.0.4
+        uses: kubewarden/github-actions/check-artifacthub@v2.0.5
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       -
         name: Build and annotate policy
-        uses: kubewarden/github-actions/policy-build-rust@v2.0.4
+        uses: kubewarden/github-actions/policy-build-rust@v2.0.5
       -
         name: Run e2e tests
         run: |
           make e2e-tests
       -
         name: Release
-        uses: kubewarden/github-actions/policy-release@v2.0.4
+        uses: kubewarden/github-actions/policy-release@v2.0.5
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}

--- a/.github/workflows/reusable-release-policy-rust.yml
+++ b/.github/workflows/reusable-release-policy-rust.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       -
         name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v2
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v2.0.4
       -
         uses: actions/checkout@v3
         with:
@@ -33,19 +33,19 @@ jobs:
       -
         name: Check that artifacthub-pkg.yml is up-to-date
         if: ${{ inputs.artifacthub }}
-        uses: kubewarden/github-actions/check-artifacthub@v2
+        uses: kubewarden/github-actions/check-artifacthub@v2.0.4
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       -
         name: Build and annotate policy
-        uses: kubewarden/github-actions/policy-build-rust@v2
+        uses: kubewarden/github-actions/policy-build-rust@v2.0.4
       -
         name: Run e2e tests
         run: |
           make e2e-tests
       -
         name: Release
-        uses: kubewarden/github-actions/policy-release@v2
+        uses: kubewarden/github-actions/policy-release@v2.0.4
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}

--- a/.github/workflows/reusable-release-policy-swift.yml
+++ b/.github/workflows/reusable-release-policy-swift.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       -
         name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v2.0.4
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v2.0.5
       -
         uses: actions/checkout@v3
         with:
@@ -33,7 +33,7 @@ jobs:
       -
         name: Check that artifacthub-pkg.yml is up-to-date
         if: ${{ inputs.artifacthub }}
-        uses: kubewarden/github-actions/check-artifacthub@v2.0.4
+        uses: kubewarden/github-actions/check-artifacthub@v2.0.5
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       -
@@ -65,7 +65,7 @@ jobs:
           make e2e-tests
       -
         name: Release
-        uses: kubewarden/github-actions/policy-release@v2.0.4
+        uses: kubewarden/github-actions/policy-release@v2.0.5
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}

--- a/.github/workflows/reusable-release-policy-swift.yml
+++ b/.github/workflows/reusable-release-policy-swift.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       -
         name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v2
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v2.0.4
       -
         uses: actions/checkout@v3
         with:
@@ -33,7 +33,7 @@ jobs:
       -
         name: Check that artifacthub-pkg.yml is up-to-date
         if: ${{ inputs.artifacthub }}
-        uses: kubewarden/github-actions/check-artifacthub@v2
+        uses: kubewarden/github-actions/check-artifacthub@v2.0.4
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       -
@@ -65,7 +65,7 @@ jobs:
           make e2e-tests
       -
         name: Release
-        uses: kubewarden/github-actions/policy-release@v2
+        uses: kubewarden/github-actions/policy-release@v2.0.4
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}

--- a/.github/workflows/reusable-test-policy-assemblyscript.yml
+++ b/.github/workflows/reusable-test-policy-assemblyscript.yml
@@ -41,14 +41,14 @@ jobs:
           fetch-depth: 0
       -
         name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v2.0.4
+        uses: kubewarden/github-actions/kwctl-installer@v2.0.5
       -
         id: calculate-version
         run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
       -
         name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthub@v2.0.4
+        uses: kubewarden/github-actions/check-artifacthub@v2.0.5
         with:
           version: ${{ steps.calculate-version.outputs.version }}
           check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then

--- a/.github/workflows/reusable-test-policy-assemblyscript.yml
+++ b/.github/workflows/reusable-test-policy-assemblyscript.yml
@@ -41,14 +41,14 @@ jobs:
           fetch-depth: 0
       -
         name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v2
+        uses: kubewarden/github-actions/kwctl-installer@v2.0.4
       -
         id: calculate-version
         run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
       -
         name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthub@v2
+        uses: kubewarden/github-actions/check-artifacthub@v2.0.4
         with:
           version: ${{ steps.calculate-version.outputs.version }}
           check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then

--- a/.github/workflows/reusable-test-policy-go.yml
+++ b/.github/workflows/reusable-test-policy-go.yml
@@ -34,14 +34,14 @@ jobs:
           fetch-depth: 0
       -
         name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v2.0.4
+        uses: kubewarden/github-actions/kwctl-installer@v2.0.5
       -
         id: calculate-version
         run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
       -
         name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthub@v2.0.4
+        uses: kubewarden/github-actions/check-artifacthub@v2.0.5
         with:
           version: ${{ steps.calculate-version.outputs.version }}
           check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then

--- a/.github/workflows/reusable-test-policy-go.yml
+++ b/.github/workflows/reusable-test-policy-go.yml
@@ -34,14 +34,14 @@ jobs:
           fetch-depth: 0
       -
         name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v2
+        uses: kubewarden/github-actions/kwctl-installer@v2.0.4
       -
         id: calculate-version
         run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
       -
         name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthub@v2
+        uses: kubewarden/github-actions/check-artifacthub@v2.0.4
         with:
           version: ${{ steps.calculate-version.outputs.version }}
           check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then

--- a/.github/workflows/reusable-test-policy-rego.yml
+++ b/.github/workflows/reusable-test-policy-rego.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v3
       -
         name: Install opa
-        uses: kubewarden/github-actions/opa-installer@v2
+        uses: kubewarden/github-actions/opa-installer@v2.0.4
       -
         name: Run unit tests
         run: make test
@@ -33,14 +33,14 @@ jobs:
           fetch-depth: 0
       -
         name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v2
+        uses: kubewarden/github-actions/kwctl-installer@v2.0.4
       -
         id: calculate-version
         run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
       -
         name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthub@v2
+        uses: kubewarden/github-actions/check-artifacthub@v2.0.4
         with:
           version: ${{ steps.calculate-version.outputs.version }}
           check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then

--- a/.github/workflows/reusable-test-policy-rego.yml
+++ b/.github/workflows/reusable-test-policy-rego.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v3
       -
         name: Install opa
-        uses: kubewarden/github-actions/opa-installer@v2.0.4
+        uses: kubewarden/github-actions/opa-installer@v2.0.5
       -
         name: Run unit tests
         run: make test
@@ -33,14 +33,14 @@ jobs:
           fetch-depth: 0
       -
         name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v2.0.4
+        uses: kubewarden/github-actions/kwctl-installer@v2.0.5
       -
         id: calculate-version
         run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
       -
         name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthub@v2.0.4
+        uses: kubewarden/github-actions/check-artifacthub@v2.0.5
         with:
           version: ${{ steps.calculate-version.outputs.version }}
           check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then

--- a/.github/workflows/reusable-test-policy-rust.yml
+++ b/.github/workflows/reusable-test-policy-rust.yml
@@ -37,14 +37,14 @@ jobs:
           fetch-depth: 0
       -
         name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v2
+        uses: kubewarden/github-actions/kwctl-installer@v2.0.4
       -
         id: calculate-version
         run: echo "version=$(sed  -n 's,^version = \"\(.*\)\",\1,p' Cargo.toml)" >> $GITHUB_OUTPUT
         shell: bash
       -
         name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthub@v2
+        uses: kubewarden/github-actions/check-artifacthub@v2.0.4
         with:
           version: ${{ steps.calculate-version.outputs.version }}
   check:

--- a/.github/workflows/reusable-test-policy-rust.yml
+++ b/.github/workflows/reusable-test-policy-rust.yml
@@ -37,14 +37,14 @@ jobs:
           fetch-depth: 0
       -
         name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v2.0.4
+        uses: kubewarden/github-actions/kwctl-installer@v2.0.5
       -
         id: calculate-version
         run: echo "version=$(sed  -n 's,^version = \"\(.*\)\",\1,p' Cargo.toml)" >> $GITHUB_OUTPUT
         shell: bash
       -
         name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthub@v2.0.4
+        uses: kubewarden/github-actions/check-artifacthub@v2.0.5
         with:
           version: ${{ steps.calculate-version.outputs.version }}
   check:

--- a/.github/workflows/reusable-test-policy-swift.yml
+++ b/.github/workflows/reusable-test-policy-swift.yml
@@ -31,14 +31,14 @@ jobs:
           fetch-depth: 0
       -
         name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v2.0.4
+        uses: kubewarden/github-actions/kwctl-installer@v2.0.5
       -
         id: calculate-version
         run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
       -
         name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthub@v2.0.4
+        uses: kubewarden/github-actions/check-artifacthub@v2.0.5
         with:
           version: ${{ steps.calculate-version.outputs.version }}
           check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then

--- a/.github/workflows/reusable-test-policy-swift.yml
+++ b/.github/workflows/reusable-test-policy-swift.yml
@@ -31,14 +31,14 @@ jobs:
           fetch-depth: 0
       -
         name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v2
+        uses: kubewarden/github-actions/kwctl-installer@v2.0.4
       -
         id: calculate-version
         run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
       -
         name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthub@v2
+        uses: kubewarden/github-actions/check-artifacthub@v2.0.4
         with:
           version: ${{ steps.calculate-version.outputs.version }}
           check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then

--- a/README.md
+++ b/README.md
@@ -16,17 +16,14 @@ management"](https://docs.github.com/en/actions/creating-actions/about-custom-ac
 
 ### Releasing a new tag
 
+1. We ourselves are consumers of our own GHA in this repo, as we
+   consume the actions in the reusable workflows. Decide on the future tag
+   version you will create, and then, preemptively update all the tags of our
+   own github-actions in this repo to that one, and commit those changes.
+   
+   We can't use RenovateBot or the like, as it would updated the tags *after* we
+   have already tagged, so the tagged version would not consume itself, but a
+   previous version.
 1. Tag your release with a semver tag (e.g: `v2.3.0`).
-
-2. Refresh the major tag (e.g: `v2`) to point to the latest version
-   corresponding to that major version. E.g: if `v2.3.0` is the last release of
-   the `v2` major version, both `v2` and `v2.3.0` tags should be pointing to the
-   same commit.
-
-   When consuming GitHub Actions they don't automatically select the major or
-   minor version for you, hence why we need to update the major tag.
-
-   Note that we are ourselves consumers of our own GHA in this repo, as we
-   consume the actions in the reusable workflows.
-3. Proof-check the GH release notes created by release drafter. Add hints on how
+1. Proof-check the GH release notes created by release drafter. Add hints on how
    to update to new version if needed.

--- a/policy-gh-action-dependencies/action.yaml
+++ b/policy-gh-action-dependencies/action.yaml
@@ -11,7 +11,7 @@ runs:
       uses: sigstore/cosign-installer@v2.8.1
     -
       name: Install kwctl
-      uses: kubewarden/github-actions/kwctl-installer@v2
+      uses: kubewarden/github-actions/kwctl-installer@v2.0.4
     -
       name: Install bats
       uses: mig4/setup-bats@v1
@@ -19,4 +19,4 @@ runs:
         bats-version: 1.5.0
     -
       name: Install SBOM generator tool
-      uses: kubewarden/github-actions/sbom-generator-installer@v2
+      uses: kubewarden/github-actions/sbom-generator-installer@v2.0.4

--- a/policy-gh-action-dependencies/action.yaml
+++ b/policy-gh-action-dependencies/action.yaml
@@ -11,7 +11,7 @@ runs:
       uses: sigstore/cosign-installer@v2.8.1
     -
       name: Install kwctl
-      uses: kubewarden/github-actions/kwctl-installer@v2.0.4
+      uses: kubewarden/github-actions/kwctl-installer@v2.0.5
     -
       name: Install bats
       uses: mig4/setup-bats@v1
@@ -19,4 +19,4 @@ runs:
         bats-version: 1.5.0
     -
       name: Install SBOM generator tool
-      uses: kubewarden/github-actions/sbom-generator-installer@v2.0.4
+      uses: kubewarden/github-actions/sbom-generator-installer@v2.0.5


### PR DESCRIPTION
## Description

- Move from self-consuming v2 to v2.0.4, in preparation for deletion of the `v2` "moving" tag.
- Document new behaviour in readme: note that we can't use Renovate Bot or the like for self-consuming, as the tagged versions would not correspond. Hence,
- Preemptively commit a bump of the version on those self-consumed github-actions, to an unexistent tag: `v2.0.5`.



## Test

Not tested.

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
- [ ] Tag as v2.0.5 on main.
- [ ] TODO create GH release. [Note that Release drafter has created a `v2.1.0`,](https://github.com/kubewarden/github-actions/releases/tag/untagged-9b2e8f38385d9a92d106) as it deems that `deps` changes are minor changes, not fixes. I will edit the release for it to be a `v2.0.5`, I'm not gonna redo the commits in this pr.
- [ ] Update all policies consuming `v2` to consume `v2.0.4` upwards.
- [ ] Delete tag `v2` now that nothing consumes it. 
