### PR TITLE
go tests add linter

### DIFF
--- a/.github/workflows/reusable-release-policy-assemblyscript.yml
+++ b/.github/workflows/reusable-release-policy-assemblyscript.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       -
         name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.0.0
+        uses: kubewarden/github-actions/policy-gh-action-dependenciesv3.0.1
       -
         uses: actions/checkout@v3
         with:
@@ -35,7 +35,7 @@ jobs:
       -
         name: Check that artifacthub-pkg.yml is up-to-date
         if: ${{ inputs.artifacthub }}
-        uses: kubewarden/github-actions/check-artifacthub@v3.0.0
+        uses: kubewarden/github-actions/check-artifacthubv3.0.1
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       -
@@ -66,7 +66,7 @@ jobs:
           make e2e-tests
       -
         name: Release
-        uses: kubewarden/github-actions/policy-release@v3.0.0
+        uses: kubewarden/github-actions/policy-releasev3.0.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}

--- a/.github/workflows/reusable-release-policy-go.yml
+++ b/.github/workflows/reusable-release-policy-go.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       -
         name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.0.0
+        uses: kubewarden/github-actions/policy-gh-action-dependenciesv3.0.1
       -
         uses: actions/checkout@v3
         with:
@@ -33,19 +33,19 @@ jobs:
       -
         name: Check that artifacthub-pkg.yml is up-to-date
         if: ${{ inputs.artifacthub }}
-        uses: kubewarden/github-actions/check-artifacthub@v3.0.0
+        uses: kubewarden/github-actions/check-artifacthubv3.0.1
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       -
         name: Build and annotate policy
-        uses: kubewarden/github-actions/policy-build-go@v3.0.0
+        uses: kubewarden/github-actions/policy-build-gov3.0.1
       -
         name: Run e2e tests
         run: |
           make e2e-tests
       -
         name: Release
-        uses: kubewarden/github-actions/policy-release@v3.0.0
+        uses: kubewarden/github-actions/policy-releasev3.0.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}

--- a/.github/workflows/reusable-release-policy-rego.yml
+++ b/.github/workflows/reusable-release-policy-rego.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       -
         name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.0.0
+        uses: kubewarden/github-actions/policy-gh-action-dependenciesv3.0.1
       -
         uses: actions/checkout@v3
         with:
@@ -33,12 +33,12 @@ jobs:
       -
         name: Check that artifacthub-pkg.yml is up-to-date
         if: ${{ inputs.artifacthub }}
-        uses: kubewarden/github-actions/check-artifacthub@v3.0.0
+        uses: kubewarden/github-actions/check-artifacthubv3.0.1
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       -
         name: Install opa
-        uses: kubewarden/github-actions/opa-installer@v3.0.0
+        uses: kubewarden/github-actions/opa-installerv3.0.1
       -
         uses: actions/checkout@v3
       -
@@ -55,7 +55,7 @@ jobs:
           make e2e-tests
       -
         name: Release
-        uses: kubewarden/github-actions/policy-release@v3.0.0
+        uses: kubewarden/github-actions/policy-releasev3.0.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}

--- a/.github/workflows/reusable-release-policy-rust.yml
+++ b/.github/workflows/reusable-release-policy-rust.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       -
         name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.0.0
+        uses: kubewarden/github-actions/policy-gh-action-dependenciesv3.0.1
       -
         uses: actions/checkout@v3
         with:
@@ -33,19 +33,19 @@ jobs:
       -
         name: Check that artifacthub-pkg.yml is up-to-date
         if: ${{ inputs.artifacthub }}
-        uses: kubewarden/github-actions/check-artifacthub@v3.0.0
+        uses: kubewarden/github-actions/check-artifacthubv3.0.1
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       -
         name: Build and annotate policy
-        uses: kubewarden/github-actions/policy-build-rust@v3.0.0
+        uses: kubewarden/github-actions/policy-build-rustv3.0.1
       -
         name: Run e2e tests
         run: |
           make e2e-tests
       -
         name: Release
-        uses: kubewarden/github-actions/policy-release@v3.0.0
+        uses: kubewarden/github-actions/policy-releasev3.0.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}

--- a/.github/workflows/reusable-release-policy-swift.yml
+++ b/.github/workflows/reusable-release-policy-swift.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       -
         name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.0.0
+        uses: kubewarden/github-actions/policy-gh-action-dependenciesv3.0.1
       -
         uses: actions/checkout@v3
         with:
@@ -33,7 +33,7 @@ jobs:
       -
         name: Check that artifacthub-pkg.yml is up-to-date
         if: ${{ inputs.artifacthub }}
-        uses: kubewarden/github-actions/check-artifacthub@v3.0.0
+        uses: kubewarden/github-actions/check-artifacthubv3.0.1
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       -
@@ -65,7 +65,7 @@ jobs:
           make e2e-tests
       -
         name: Release
-        uses: kubewarden/github-actions/policy-release@v3.0.0
+        uses: kubewarden/github-actions/policy-releasev3.0.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}

--- a/.github/workflows/reusable-test-policy-assemblyscript.yml
+++ b/.github/workflows/reusable-test-policy-assemblyscript.yml
@@ -41,14 +41,14 @@ jobs:
           fetch-depth: 0
       -
         name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v3.0.0
+        uses: kubewarden/github-actions/kwctl-installerv3.0.1
       -
         id: calculate-version
         run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
       -
         name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthub@v3.0.0
+        uses: kubewarden/github-actions/check-artifacthubv3.0.1
         with:
           version: ${{ steps.calculate-version.outputs.version }}
           check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then

--- a/.github/workflows/reusable-test-policy-go.yml
+++ b/.github/workflows/reusable-test-policy-go.yml
@@ -34,14 +34,14 @@ jobs:
           fetch-depth: 0
       -
         name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v3.0.0
+        uses: kubewarden/github-actions/kwctl-installerv3.0.1
       -
         id: calculate-version
         run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
       -
         name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthub@v3.0.0
+        uses: kubewarden/github-actions/check-artifacthubv3.0.1
         with:
           version: ${{ steps.calculate-version.outputs.version }}
           check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then

--- a/.github/workflows/reusable-test-policy-go.yml
+++ b/.github/workflows/reusable-test-policy-go.yml
@@ -19,10 +19,23 @@ jobs:
       - name: setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.17'
+          go-version: 'stable'
 
       - name: run Go unit tests
         run: make test
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v4
+        with:
+          go-version: 'latest'
+      - uses: actions/checkout@v3
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: 'latest'
+
   check-artifacthub:
     if: ${{ inputs.artifacthub }}
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable-test-policy-rego.yml
+++ b/.github/workflows/reusable-test-policy-rego.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v3
       -
         name: Install opa
-        uses: kubewarden/github-actions/opa-installer@v3.0.0
+        uses: kubewarden/github-actions/opa-installerv3.0.1
       -
         name: Run unit tests
         run: make test
@@ -33,14 +33,14 @@ jobs:
           fetch-depth: 0
       -
         name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v3.0.0
+        uses: kubewarden/github-actions/kwctl-installerv3.0.1
       -
         id: calculate-version
         run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
       -
         name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthub@v3.0.0
+        uses: kubewarden/github-actions/check-artifacthubv3.0.1
         with:
           version: ${{ steps.calculate-version.outputs.version }}
           check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then

--- a/.github/workflows/reusable-test-policy-rust.yml
+++ b/.github/workflows/reusable-test-policy-rust.yml
@@ -37,14 +37,14 @@ jobs:
           fetch-depth: 0
       -
         name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v3.0.0
+        uses: kubewarden/github-actions/kwctl-installerv3.0.1
       -
         id: calculate-version
         run: echo "version=$(sed  -n 's,^version = \"\(.*\)\",\1,p' Cargo.toml)" >> $GITHUB_OUTPUT
         shell: bash
       -
         name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthub@v3.0.0
+        uses: kubewarden/github-actions/check-artifacthubv3.0.1
         with:
           version: ${{ steps.calculate-version.outputs.version }}
   check:

--- a/.github/workflows/reusable-test-policy-swift.yml
+++ b/.github/workflows/reusable-test-policy-swift.yml
@@ -31,14 +31,14 @@ jobs:
           fetch-depth: 0
       -
         name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v3.0.0
+        uses: kubewarden/github-actions/kwctl-installerv3.0.1
       -
         id: calculate-version
         run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
       -
         name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthub@v3.0.0
+        uses: kubewarden/github-actions/check-artifacthubv3.0.1
         with:
           version: ${{ steps.calculate-version.outputs.version }}
           check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then

--- a/policy-build-go/action.yaml
+++ b/policy-build-go/action.yaml
@@ -11,21 +11,7 @@ runs:
   using: "composite"
   steps:
     -
-      name: Checkout code
-      uses: actions/checkout@v3
-    -
-      name: Install tinygo
-      shell: bash
-      run: |
-        wget https://github.com/tinygo-org/tinygo/releases/download/v${{ inputs.tinygo-version }}/tinygo_${{ inputs.tinygo-version }}_amd64.deb
-        sudo dpkg -i tinygo_${{ inputs.tinygo-version }}_amd64.deb
-    -
-      name: Build Wasm module
-      shell: bash
-      run: |
-        tinygo build -o policy.wasm -target=wasi -no-debug .
-    -
-      name: Generate the SBOM files
+      name: Checkname: Generate the SBOM files
       shell: bash
       run: |
         spdx-sbom-generator -f json

--- a/policy-build-go/action.yaml
+++ b/policy-build-go/action.yaml
@@ -23,7 +23,7 @@ runs:
       name: Build Wasm module
       shell: bash
       run: |
-        tinygo build -o ${{ inputs.wasm-binary }} -target=wasi -no-debug .
+        tinygo build -o policy.wasm -target=wasi -no-debug .
     -
       name: Generate the SBOM files
       shell: bash

--- a/policy-build-rust/action.yaml
+++ b/policy-build-rust/action.yaml
@@ -3,15 +3,6 @@ description: 'Build a rust policy using rust'
 branding:
   icon: 'package'
   color: 'blue'
-inputs:
-  metadata-file:
-    description: 'name of the metata file'
-    required: false
-    default: metadata.yml
-  input-wasm:
-    description: 'path to the wasm file to be annotated'
-    required: false
-    default: policy.wasm
 runs:
   using: "composite"
   steps:
@@ -35,12 +26,12 @@ runs:
       name: Rename Wasm module
       shell: bash
       run: |
-        cp target/wasm32-wasi/release/*.wasm ${{ inputs.input-wasm }}
+        cp target/wasm32-wasi/release/*.wasm policy.wasm
     -
       name: Annotate Wasm module
       shell: bash
       run: |
-        kwctl annotate -m ${{ inputs.metadata-file }} -o annotated-policy.wasm ${{ inputs.input-wasm }}
+        make annotated-policy.wasm
     -
       name: Generate the SBOM files
       shell: bash

--- a/policy-gh-action-dependencies/action.yaml
+++ b/policy-gh-action-dependencies/action.yaml
@@ -11,7 +11,7 @@ runs:
       uses: sigstore/cosign-installer@v2.8.1
     -
       name: Install kwctl
-      uses: kubewarden/github-actions/kwctl-installer@v3.0.0
+      uses: kubewarden/github-actions/kwctl-installerv3.0.1
     -
       name: Install bats
       uses: mig4/setup-bats@v1
@@ -19,4 +19,4 @@ runs:
         bats-version: 1.5.0
     -
       name: Install SBOM generator tool
-      uses: kubewarden/github-actions/sbom-generator-installer@v3.0.0
+      uses: kubewarden/github-actions/sbom-generator-installerv3.0.1


### PR DESCRIPTION
> **Note:** this PR is based on top of https://github.com/kubewarden/github-actions/pull/63

Minor improvements to go reusable test

* Use the latest stable release of Go when building the unit tests
* Add lint tests via golang-ci
