### PR TITLE
fix: speficy `use` references in the proper way

### DIFF
--- a/.github/workflows/reusable-release-policy-assemblyscript.yml
+++ b/.github/workflows/reusable-release-policy-assemblyscript.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       -
         name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.0.1
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.0.2
       -
         uses: actions/checkout@v3
         with:
@@ -35,7 +35,7 @@ jobs:
       -
         name: Check that artifacthub-pkg.yml is up-to-date
         if: ${{ inputs.artifacthub }}
-        uses: kubewarden/github-actions/check-artifacthub@v3.0.1
+        uses: kubewarden/github-actions/check-artifacthub@v3.0.2
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       -
@@ -66,7 +66,7 @@ jobs:
           make e2e-tests
       -
         name: Release
-        uses: kubewarden/github-actions/policy-release@v3.0.1
+        uses: kubewarden/github-actions/policy-release@v3.0.2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}

--- a/.github/workflows/reusable-release-policy-assemblyscript.yml
+++ b/.github/workflows/reusable-release-policy-assemblyscript.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       -
         name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependenciesv3.0.1
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.0.1
       -
         uses: actions/checkout@v3
         with:
@@ -35,7 +35,7 @@ jobs:
       -
         name: Check that artifacthub-pkg.yml is up-to-date
         if: ${{ inputs.artifacthub }}
-        uses: kubewarden/github-actions/check-artifacthubv3.0.1
+        uses: kubewarden/github-actions/check-artifacthub@v3.0.1
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       -
@@ -66,7 +66,7 @@ jobs:
           make e2e-tests
       -
         name: Release
-        uses: kubewarden/github-actions/policy-releasev3.0.1
+        uses: kubewarden/github-actions/policy-release@v3.0.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}

--- a/.github/workflows/reusable-release-policy-go.yml
+++ b/.github/workflows/reusable-release-policy-go.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       -
         name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.0.1
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.0.2
       -
         uses: actions/checkout@v3
         with:
@@ -33,19 +33,19 @@ jobs:
       -
         name: Check that artifacthub-pkg.yml is up-to-date
         if: ${{ inputs.artifacthub }}
-        uses: kubewarden/github-actions/check-artifacthub@v3.0.1
+        uses: kubewarden/github-actions/check-artifacthub@v3.0.2
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       -
         name: Build and annotate policy
-        uses: kubewarden/github-actions/policy-build-go@v3.0.1
+        uses: kubewarden/github-actions/policy-build-go@v3.0.2
       -
         name: Run e2e tests
         run: |
           make e2e-tests
       -
         name: Release
-        uses: kubewarden/github-actions/policy-release@v3.0.1
+        uses: kubewarden/github-actions/policy-release@v3.0.2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}

--- a/.github/workflows/reusable-release-policy-go.yml
+++ b/.github/workflows/reusable-release-policy-go.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       -
         name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependenciesv3.0.1
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.0.1
       -
         uses: actions/checkout@v3
         with:
@@ -33,19 +33,19 @@ jobs:
       -
         name: Check that artifacthub-pkg.yml is up-to-date
         if: ${{ inputs.artifacthub }}
-        uses: kubewarden/github-actions/check-artifacthubv3.0.1
+        uses: kubewarden/github-actions/check-artifacthub@v3.0.1
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       -
         name: Build and annotate policy
-        uses: kubewarden/github-actions/policy-build-gov3.0.1
+        uses: kubewarden/github-actions/policy-build-go@v3.0.1
       -
         name: Run e2e tests
         run: |
           make e2e-tests
       -
         name: Release
-        uses: kubewarden/github-actions/policy-releasev3.0.1
+        uses: kubewarden/github-actions/policy-release@v3.0.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}

--- a/.github/workflows/reusable-release-policy-rego.yml
+++ b/.github/workflows/reusable-release-policy-rego.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       -
         name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.0.1
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.0.2
       -
         uses: actions/checkout@v3
         with:
@@ -33,12 +33,12 @@ jobs:
       -
         name: Check that artifacthub-pkg.yml is up-to-date
         if: ${{ inputs.artifacthub }}
-        uses: kubewarden/github-actions/check-artifacthub@v3.0.1
+        uses: kubewarden/github-actions/check-artifacthub@v3.0.2
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       -
         name: Install opa
-        uses: kubewarden/github-actions/opa-installer@v3.0.1
+        uses: kubewarden/github-actions/opa-installer@v3.0.2
       -
         uses: actions/checkout@v3
       -
@@ -55,7 +55,7 @@ jobs:
           make e2e-tests
       -
         name: Release
-        uses: kubewarden/github-actions/policy-release@v3.0.1
+        uses: kubewarden/github-actions/policy-release@v3.0.2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}

--- a/.github/workflows/reusable-release-policy-rego.yml
+++ b/.github/workflows/reusable-release-policy-rego.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       -
         name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependenciesv3.0.1
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.0.1
       -
         uses: actions/checkout@v3
         with:
@@ -33,12 +33,12 @@ jobs:
       -
         name: Check that artifacthub-pkg.yml is up-to-date
         if: ${{ inputs.artifacthub }}
-        uses: kubewarden/github-actions/check-artifacthubv3.0.1
+        uses: kubewarden/github-actions/check-artifacthub@v3.0.1
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       -
         name: Install opa
-        uses: kubewarden/github-actions/opa-installerv3.0.1
+        uses: kubewarden/github-actions/opa-installer@v3.0.1
       -
         uses: actions/checkout@v3
       -
@@ -55,7 +55,7 @@ jobs:
           make e2e-tests
       -
         name: Release
-        uses: kubewarden/github-actions/policy-releasev3.0.1
+        uses: kubewarden/github-actions/policy-release@v3.0.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}

--- a/.github/workflows/reusable-release-policy-rust.yml
+++ b/.github/workflows/reusable-release-policy-rust.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       -
         name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependenciesv3.0.1
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.0.1
       -
         uses: actions/checkout@v3
         with:
@@ -33,19 +33,19 @@ jobs:
       -
         name: Check that artifacthub-pkg.yml is up-to-date
         if: ${{ inputs.artifacthub }}
-        uses: kubewarden/github-actions/check-artifacthubv3.0.1
+        uses: kubewarden/github-actions/check-artifacthub@v3.0.1
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       -
         name: Build and annotate policy
-        uses: kubewarden/github-actions/policy-build-rustv3.0.1
+        uses: kubewarden/github-actions/policy-build-rust@v3.0.1
       -
         name: Run e2e tests
         run: |
           make e2e-tests
       -
         name: Release
-        uses: kubewarden/github-actions/policy-releasev3.0.1
+        uses: kubewarden/github-actions/policy-release@v3.0.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}

--- a/.github/workflows/reusable-release-policy-rust.yml
+++ b/.github/workflows/reusable-release-policy-rust.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       -
         name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.0.1
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.0.2
       -
         uses: actions/checkout@v3
         with:
@@ -33,19 +33,19 @@ jobs:
       -
         name: Check that artifacthub-pkg.yml is up-to-date
         if: ${{ inputs.artifacthub }}
-        uses: kubewarden/github-actions/check-artifacthub@v3.0.1
+        uses: kubewarden/github-actions/check-artifacthub@v3.0.2
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       -
         name: Build and annotate policy
-        uses: kubewarden/github-actions/policy-build-rust@v3.0.1
+        uses: kubewarden/github-actions/policy-build-rust@v3.0.2
       -
         name: Run e2e tests
         run: |
           make e2e-tests
       -
         name: Release
-        uses: kubewarden/github-actions/policy-release@v3.0.1
+        uses: kubewarden/github-actions/policy-release@v3.0.2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}

--- a/.github/workflows/reusable-release-policy-swift.yml
+++ b/.github/workflows/reusable-release-policy-swift.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       -
         name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependenciesv3.0.1
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.0.1
       -
         uses: actions/checkout@v3
         with:
@@ -33,7 +33,7 @@ jobs:
       -
         name: Check that artifacthub-pkg.yml is up-to-date
         if: ${{ inputs.artifacthub }}
-        uses: kubewarden/github-actions/check-artifacthubv3.0.1
+        uses: kubewarden/github-actions/check-artifacthub@v3.0.1
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       -
@@ -65,7 +65,7 @@ jobs:
           make e2e-tests
       -
         name: Release
-        uses: kubewarden/github-actions/policy-releasev3.0.1
+        uses: kubewarden/github-actions/policy-release@v3.0.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}

--- a/.github/workflows/reusable-release-policy-swift.yml
+++ b/.github/workflows/reusable-release-policy-swift.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       -
         name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.0.1
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.0.2
       -
         uses: actions/checkout@v3
         with:
@@ -33,7 +33,7 @@ jobs:
       -
         name: Check that artifacthub-pkg.yml is up-to-date
         if: ${{ inputs.artifacthub }}
-        uses: kubewarden/github-actions/check-artifacthub@v3.0.1
+        uses: kubewarden/github-actions/check-artifacthub@v3.0.2
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       -
@@ -65,7 +65,7 @@ jobs:
           make e2e-tests
       -
         name: Release
-        uses: kubewarden/github-actions/policy-release@v3.0.1
+        uses: kubewarden/github-actions/policy-release@v3.0.2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}

--- a/.github/workflows/reusable-test-policy-assemblyscript.yml
+++ b/.github/workflows/reusable-test-policy-assemblyscript.yml
@@ -41,14 +41,14 @@ jobs:
           fetch-depth: 0
       -
         name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installerv3.0.1
+        uses: kubewarden/github-actions/kwctl-installer@v3.0.1
       -
         id: calculate-version
         run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
       -
         name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthubv3.0.1
+        uses: kubewarden/github-actions/check-artifacthub@v3.0.1
         with:
           version: ${{ steps.calculate-version.outputs.version }}
           check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then

--- a/.github/workflows/reusable-test-policy-assemblyscript.yml
+++ b/.github/workflows/reusable-test-policy-assemblyscript.yml
@@ -41,14 +41,14 @@ jobs:
           fetch-depth: 0
       -
         name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v3.0.1
+        uses: kubewarden/github-actions/kwctl-installer@v3.0.2
       -
         id: calculate-version
         run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
       -
         name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthub@v3.0.1
+        uses: kubewarden/github-actions/check-artifacthub@v3.0.2
         with:
           version: ${{ steps.calculate-version.outputs.version }}
           check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then

--- a/.github/workflows/reusable-test-policy-go.yml
+++ b/.github/workflows/reusable-test-policy-go.yml
@@ -47,14 +47,14 @@ jobs:
           fetch-depth: 0
       -
         name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installerv3.0.1
+        uses: kubewarden/github-actions/kwctl-installer@v3.0.1
       -
         id: calculate-version
         run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
       -
         name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthubv3.0.1
+        uses: kubewarden/github-actions/check-artifacthub@v3.0.1
         with:
           version: ${{ steps.calculate-version.outputs.version }}
           check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then

--- a/.github/workflows/reusable-test-policy-go.yml
+++ b/.github/workflows/reusable-test-policy-go.yml
@@ -47,14 +47,14 @@ jobs:
           fetch-depth: 0
       -
         name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v3.0.1
+        uses: kubewarden/github-actions/kwctl-installer@v3.0.2
       -
         id: calculate-version
         run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
       -
         name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthub@v3.0.1
+        uses: kubewarden/github-actions/check-artifacthub@v3.0.2
         with:
           version: ${{ steps.calculate-version.outputs.version }}
           check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then

--- a/.github/workflows/reusable-test-policy-rego.yml
+++ b/.github/workflows/reusable-test-policy-rego.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v3
       -
         name: Install opa
-        uses: kubewarden/github-actions/opa-installer@v3.0.1
+        uses: kubewarden/github-actions/opa-installer@v3.0.2
       -
         name: Run unit tests
         run: make test
@@ -33,14 +33,14 @@ jobs:
           fetch-depth: 0
       -
         name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v3.0.1
+        uses: kubewarden/github-actions/kwctl-installer@v3.0.2
       -
         id: calculate-version
         run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
       -
         name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthub@v3.0.1
+        uses: kubewarden/github-actions/check-artifacthub@v3.0.2
         with:
           version: ${{ steps.calculate-version.outputs.version }}
           check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then

--- a/.github/workflows/reusable-test-policy-rego.yml
+++ b/.github/workflows/reusable-test-policy-rego.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v3
       -
         name: Install opa
-        uses: kubewarden/github-actions/opa-installerv3.0.1
+        uses: kubewarden/github-actions/opa-installer@v3.0.1
       -
         name: Run unit tests
         run: make test
@@ -33,14 +33,14 @@ jobs:
           fetch-depth: 0
       -
         name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installerv3.0.1
+        uses: kubewarden/github-actions/kwctl-installer@v3.0.1
       -
         id: calculate-version
         run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
       -
         name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthubv3.0.1
+        uses: kubewarden/github-actions/check-artifacthub@v3.0.1
         with:
           version: ${{ steps.calculate-version.outputs.version }}
           check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then

--- a/.github/workflows/reusable-test-policy-rust.yml
+++ b/.github/workflows/reusable-test-policy-rust.yml
@@ -37,14 +37,14 @@ jobs:
           fetch-depth: 0
       -
         name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installerv3.0.1
+        uses: kubewarden/github-actions/kwctl-installer@v3.0.1
       -
         id: calculate-version
         run: echo "version=$(sed  -n 's,^version = \"\(.*\)\",\1,p' Cargo.toml)" >> $GITHUB_OUTPUT
         shell: bash
       -
         name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthubv3.0.1
+        uses: kubewarden/github-actions/check-artifacthub@v3.0.1
         with:
           version: ${{ steps.calculate-version.outputs.version }}
   check:

--- a/.github/workflows/reusable-test-policy-rust.yml
+++ b/.github/workflows/reusable-test-policy-rust.yml
@@ -37,14 +37,14 @@ jobs:
           fetch-depth: 0
       -
         name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v3.0.1
+        uses: kubewarden/github-actions/kwctl-installer@v3.0.2
       -
         id: calculate-version
         run: echo "version=$(sed  -n 's,^version = \"\(.*\)\",\1,p' Cargo.toml)" >> $GITHUB_OUTPUT
         shell: bash
       -
         name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthub@v3.0.1
+        uses: kubewarden/github-actions/check-artifacthub@v3.0.2
         with:
           version: ${{ steps.calculate-version.outputs.version }}
   check:

--- a/.github/workflows/reusable-test-policy-swift.yml
+++ b/.github/workflows/reusable-test-policy-swift.yml
@@ -31,14 +31,14 @@ jobs:
           fetch-depth: 0
       -
         name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v3.0.1
+        uses: kubewarden/github-actions/kwctl-installer@v3.0.2
       -
         id: calculate-version
         run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
       -
         name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthub@v3.0.1
+        uses: kubewarden/github-actions/check-artifacthub@v3.0.2
         with:
           version: ${{ steps.calculate-version.outputs.version }}
           check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then

--- a/.github/workflows/reusable-test-policy-swift.yml
+++ b/.github/workflows/reusable-test-policy-swift.yml
@@ -31,14 +31,14 @@ jobs:
           fetch-depth: 0
       -
         name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installerv3.0.1
+        uses: kubewarden/github-actions/kwctl-installer@v3.0.1
       -
         id: calculate-version
         run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
       -
         name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthubv3.0.1
+        uses: kubewarden/github-actions/check-artifacthub@v3.0.1
         with:
           version: ${{ steps.calculate-version.outputs.version }}
           check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then

--- a/policy-gh-action-dependencies/action.yaml
+++ b/policy-gh-action-dependencies/action.yaml
@@ -11,7 +11,7 @@ runs:
       uses: sigstore/cosign-installer@v2.8.1
     -
       name: Install kwctl
-      uses: kubewarden/github-actions/kwctl-installerv3.0.1
+      uses: kubewarden/github-actions/kwctl-installerv3.0.2
     -
       name: Install bats
       uses: mig4/setup-bats@v1
@@ -19,4 +19,4 @@ runs:
         bats-version: 1.5.0
     -
       name: Install SBOM generator tool
-      uses: kubewarden/github-actions/sbom-generator-installerv3.0.1
+      uses: kubewarden/github-actions/sbom-generator-installerv3.0.2


### PR DESCRIPTION
Ensure the `use` references are expressed in the proper way.

@viccuad that was a regression introduced with the 3.0.1 release. I wonder if I should now update all the references to be 3.0.2 and tag a v3.0.2 release.

I'm confused... :thinking: 