### PR TITLE
fix: Reinstate building steps in policy-build-go

### DIFF
--- a/policy-build-go/action.yaml
+++ b/policy-build-go/action.yaml
@@ -11,7 +11,21 @@ runs:
   using: "composite"
   steps:
     -
-      name: Checkname: Generate the SBOM files
+      name: Checkout code
+      uses: actions/checkout@v3
+    -
+      name: Install tinygo
+      shell: bash
+      run: |
+        wget https://github.com/tinygo-org/tinygo/releases/download/v${{ inputs.tinygo-version }}/tinygo_${{ inputs.tinygo-version }}_amd64.deb
+        sudo dpkg -i tinygo_${{ inputs.tinygo-version }}_amd64.deb
+    -
+      name: Build Wasm module
+      shell: bash
+      run: |
+        tinygo build -o policy.wasm -target=wasi -no-debug .
+    -
+      name: Generate the SBOM files
       shell: bash
       run: |
         spdx-sbom-generator -f json


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
fix: Reinstate building steps in policy-build-go

Incorrectly removed in https://github.com/kubewarden/github-actions/pull/63.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

Not tested.

## Additional Information

Will get released as part of v3.0.2

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
