### PR TITLE
chore(deps): update tinygo version

### DIFF
--- a/policy-build-go/action.yml
+++ b/policy-build-go/action.yml
@@ -6,7 +6,7 @@ branding:
 inputs:
   tinygo-version:
     required: true
-    default: 0.26.0
+    default: 0.27.0
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
Go policies: use latest version of tinygo to build the policy during the release process.

This will hopefully fix release errors like [this one](https://github.com/kubewarden/sysctl-psp-policy/actions/runs/4667070845/jobs/8262408213):


```
Run tinygo build -o policy.wasm -target=wasi -no-debug .
  tinygo build -o policy.wasm -target=wasi -no-debug .
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
error: requires go version 1.18 through 1.19, got go1.20
```

The latest version of tinygo should be happy when go 1.20 is found
