### PR TITLE
Update cert-manager to 1.11.0

### DIFF
--- a/setup-kubewarden-cluster-action/action.yml
+++ b/setup-kubewarden-cluster-action/action.yml
@@ -99,7 +99,7 @@ runs:
       id: install
     - name: "Install cert-manager and wait to be ready"
       run: |
-        kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.5.3/cert-manager.yaml
+        kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.11.0/cert-manager.yaml
         kubectl wait --for=condition=Available deployment --timeout=3m -n cert-manager --all
       shell: bash
     - name: "Install Kubewarden Helm repository"


### PR DESCRIPTION
Rancher 2.7.2 [moved to cert-manager 1.11.0](https://github.com/rancher/rancher/releases/tag/v2.7.2)

We still point to cert-manager 1.5.3 in our docs, which is almost 2 years old.