### PR TITLE
Updates cosign to v2.

### DIFF
--- a/policy-build-go/action.yml
+++ b/policy-build-go/action.yml
@@ -42,11 +42,9 @@ runs:
       name: Sign BOM file
       shell: bash
       run: |
-        cosign sign-blob --output-certificate policy-sbom.spdx.cert \
+        cosign sign-blob --yes --output-certificate policy-sbom.spdx.cert \
           --output-signature policy-sbom.spdx.sig \
           policy-sbom.spdx.json
-      env:
-        COSIGN_EXPERIMENTAL: 1
     -
       name:  Upload policy SBOM files
       uses: actions/upload-artifact@v3

--- a/policy-build-rust/action.yml
+++ b/policy-build-rust/action.yml
@@ -45,11 +45,9 @@ runs:
       name: Sign BOM file
       shell: bash
       run: |
-        cosign sign-blob --output-certificate policy-sbom.spdx.cert \
+        cosign sign-blob --yes --output-certificate policy-sbom.spdx.cert \
           --output-signature policy-sbom.spdx.sig \
           policy-sbom.spdx.json
-      env:
-        COSIGN_EXPERIMENTAL: 1
     -
       name:  Upload policy SBOM files
       uses: actions/upload-artifact@v3

--- a/policy-gh-action-dependencies/action.yml
+++ b/policy-gh-action-dependencies/action.yml
@@ -8,7 +8,7 @@ runs:
   steps:
     -
       name: Install cosign
-      uses: sigstore/cosign-installer@v2.8.1
+      uses: sigstore/cosign-installer@v3
     -
       name: Install kwctl
       uses: kubewarden/github-actions/kwctl-installer@v3.1.4

--- a/policy-release/action.yml
+++ b/policy-release/action.yml
@@ -36,7 +36,7 @@ runs:
         IMMUTABLE_REF=$(kwctl push -o json ${{ inputs.annotated-wasm }} ${{ inputs.oci-target }}:latest | jq -r .immutable_ref)
 
         echo Keyless signing of policy using cosign
-        cosign sign ${IMMUTABLE_REF}
+        cosign sign --yes ${IMMUTABLE_REF}
     -
       name: Publish Wasm policy artifact to OCI registry with the version tag and 'latest'
       shell: bash
@@ -51,7 +51,7 @@ runs:
         IMMUTABLE_REF=$(kwctl push -o json ${{ inputs.annotated-wasm }} ${{ inputs.oci-target }}:${OCI_TAG} | jq -r .immutable_ref)
 
         echo Keyless signing of policy using cosign
-        cosign sign ${IMMUTABLE_REF}
+        cosign sign --yes ${IMMUTABLE_REF}
     -
       name: Create release
       if: ${{ startsWith(github.ref, 'refs/tags/') }}


### PR DESCRIPTION
## Description

Updates the CI scripts updating the cosign-installer to v3. Thus, the cosign version now is v2. Which has breaking changes requiring some changes on how the command is called and removing the need of using environment variable to enable keyless signature.

Related to https://github.com/kubewarden/kubewarden-controller/issues/411