### PR TITLE
build: bump tinygo version to 0.28.1

### DIFF
--- a/policy-build-go/action.yml
+++ b/policy-build-go/action.yml
@@ -6,7 +6,7 @@ branding:
 inputs:
   tinygo-version:
     required: true
-    default: 0.27.0
+    default: 0.28.1
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
## Description
bumps tinygo to the latest stable version. 

## Test

-

## Additional Information

### Tradeoff

-
