### PR TITLE
ci: add e2e tests step to reusable test policy go

### DIFF
--- a/.github/workflows/reusable-test-policy-go.yml
+++ b/.github/workflows/reusable-test-policy-go.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       artifacthub:
-        description: 'check artifacthub-pkg.yml for submission to ArtifactHub'
+        description: "check artifacthub-pkg.yml for submission to ArtifactHub"
         required: false
         type: boolean
         default: true
@@ -19,41 +19,50 @@ jobs:
       - name: setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: 'stable'
+          go-version: "stable"
 
       - name: run Go unit tests
         run: make test
+
+  e2e-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.1.6
+      - name: Build and annotate policy
+        with:
+          generate-sbom: false
+        uses: kubewarden/github-actions/policy-build-go@3.1.6
+      - name: Run e2e tests
+        run: make e2e-tests
 
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: 'stable'
+          go-version: "stable"
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: 'latest'
+          version: "latest"
 
   check-artifacthub:
     if: ${{ inputs.artifacthub }}
     runs-on: ubuntu-latest
     steps:
-      -
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
         with:
           # until https://github.com/actions/checkout/pull/579 is released
           fetch-depth: 0
-      -
-        name: Install kwctl
+      - name: Install kwctl
         uses: kubewarden/github-actions/kwctl-installer@v3.1.6
-      -
-        id: calculate-version
+      - id: calculate-version
         run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
-      -
-        name: Check that artifacthub-pkg.yml is up-to-date
+      - name: Check that artifacthub-pkg.yml is up-to-date
         uses: kubewarden/github-actions/check-artifacthub@v3.1.6
         with:
           version: ${{ steps.calculate-version.outputs.version }}

--- a/policy-build-go/action.yml
+++ b/policy-build-go/action.yml
@@ -1,31 +1,35 @@
-name: 'kubewarden-policy-build-go'
-description: 'Build a go policy using go'
+name: "kubewarden-policy-build-go"
+description: "Build a go policy using go"
 branding:
-  icon: 'package'
-  color: 'blue'
+  icon: "package"
+  color: "blue"
 inputs:
   tinygo-version:
     required: true
+    description: "Version of tinygo to use"
     default: 0.28.1
+  generate-sbom:
+    required: false
+    description: "Generate and sign SBOM files"
+    # Boolean input should be compared with string
+    # until https://github.com/actions/runner/issues/2238 resolved
+    default: "true"
 runs:
   using: "composite"
   steps:
-    -
-      name: Checkout code
+    - name: Checkout code
       uses: actions/checkout@v3
-    -
-      name: Install tinygo
+    - name: Install tinygo
       shell: bash
       run: |
         wget https://github.com/tinygo-org/tinygo/releases/download/v${{ inputs.tinygo-version }}/tinygo_${{ inputs.tinygo-version }}_amd64.deb
         sudo dpkg -i tinygo_${{ inputs.tinygo-version }}_amd64.deb
-    -
-      name: Build Wasm module
+    - name: Build Wasm module
       shell: bash
       run: |
         tinygo build -o policy.wasm -target=wasi -no-debug .
-    -
-      name: Generate the SBOM files
+    - name: Generate the SBOM files
+      if: ${{ inputs.generate-sbom == 'true' }}
       shell: bash
       run: |
         spdx-sbom-generator -f json
@@ -33,20 +37,19 @@ runs:
         # SBOM files should have "sbom" in the name due the CLO monitor
         # https://clomonitor.io/docs/topics/checks/#software-bill-of-materials-sbom
         mv bom-go-mod.json policy-sbom.spdx.json
-    -
-      name: Annotate Wasm module
+    - name: Annotate Wasm module
       shell: bash
       run: |
         make annotated-policy.wasm
-    -
-      name: Sign BOM file
+    - name: Sign BOM file
+      if: ${{ inputs.generate-sbom == 'true' }}
       shell: bash
       run: |
         cosign sign-blob --yes --output-certificate policy-sbom.spdx.cert \
           --output-signature policy-sbom.spdx.sig \
           policy-sbom.spdx.json
-    -
-      name:  Upload policy SBOM files
+    - name: Upload policy SBOM files
+      if: ${{ inputs.generate-sbom == 'true' }}
       uses: actions/upload-artifact@v3
       with:
         name: policy-sbom


### PR DESCRIPTION
## Description

Adds the e2e test step to the `reusable-test-policy-go` action.
It also adds an option to the `policy-build-go` action to disable the SBOM generation, which saves some time when running e2e tests in a non-release scenario.

## Test

Tested in fork

## Additional Information

-
