### PR TITLE
deps: bump kwctl-installer to v1.9.0-rc2

### DIFF
--- a/.github/workflows/reusable-release-policy-assemblyscript.yml
+++ b/.github/workflows/reusable-release-policy-assemblyscript.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       -
         name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.1.10
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.1.11
       -
         uses: actions/checkout@v4
         with:
@@ -37,7 +37,7 @@ jobs:
         name: Check that artifacthub-pkg.yml is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub
-        uses: kubewarden/github-actions/check-artifacthub@v3.1.10
+        uses: kubewarden/github-actions/check-artifacthub@v3.1.11
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       -
@@ -68,7 +68,7 @@ jobs:
           make e2e-tests
       -
         name: Release
-        uses: kubewarden/github-actions/policy-release@v3.1.10
+        uses: kubewarden/github-actions/policy-release@v3.1.11
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -84,4 +84,4 @@ jobs:
     steps:
       -
         name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v3.1.10
+        uses: kubewarden/github-actions/push-artifacthub@v3.1.11

--- a/.github/workflows/reusable-release-policy-go.yml
+++ b/.github/workflows/reusable-release-policy-go.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       -
         name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.1.10
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.1.11
       -
         uses: actions/checkout@v4
         with:
@@ -35,19 +35,19 @@ jobs:
         name: Check that artifacthub-pkg.yml is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub
-        uses: kubewarden/github-actions/check-artifacthub@v3.1.10
+        uses: kubewarden/github-actions/check-artifacthub@v3.1.11
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       -
         name: Build and annotate policy
-        uses: kubewarden/github-actions/policy-build-go@v3.1.10
+        uses: kubewarden/github-actions/policy-build-go@v3.1.11
       -
         name: Run e2e tests
         run: |
           make e2e-tests
       -
         name: Release
-        uses: kubewarden/github-actions/policy-release@v3.1.10
+        uses: kubewarden/github-actions/policy-release@v3.1.11
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -63,4 +63,4 @@ jobs:
     steps:
       -
         name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v3.1.10
+        uses: kubewarden/github-actions/push-artifacthub@v3.1.11

--- a/.github/workflows/reusable-release-policy-rego.yml
+++ b/.github/workflows/reusable-release-policy-rego.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       -
         name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.1.10
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.1.11
       -
         uses: actions/checkout@v4
         with:
@@ -35,12 +35,12 @@ jobs:
         name: Check that artifacthub-pkg.yml is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub
-        uses: kubewarden/github-actions/check-artifacthub@v3.1.10
+        uses: kubewarden/github-actions/check-artifacthub@v3.1.11
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       -
         name: Install opa
-        uses: kubewarden/github-actions/opa-installer@v3.1.10
+        uses: kubewarden/github-actions/opa-installer@v3.1.11
       -
         uses: actions/checkout@v4
       -
@@ -57,7 +57,7 @@ jobs:
           make e2e-tests
       -
         name: Release
-        uses: kubewarden/github-actions/policy-release@v3.1.10
+        uses: kubewarden/github-actions/policy-release@v3.1.11
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -73,4 +73,4 @@ jobs:
     steps:
       -
         name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v3.1.10
+        uses: kubewarden/github-actions/push-artifacthub@v3.1.11

--- a/.github/workflows/reusable-release-policy-rust.yml
+++ b/.github/workflows/reusable-release-policy-rust.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       -
         name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.1.10
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.1.11
       -
         uses: actions/checkout@v4
         with:
@@ -34,19 +34,19 @@ jobs:
         name: Check that artifacthub-pkg.yml is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub
-        uses: kubewarden/github-actions/check-artifacthub@v3.1.10
+        uses: kubewarden/github-actions/check-artifacthub@v3.1.11
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       -
         name: Build and annotate policy
-        uses: kubewarden/github-actions/policy-build-rust@v3.1.10
+        uses: kubewarden/github-actions/policy-build-rust@v3.1.11
       -
         name: Run e2e tests
         run: |
           make e2e-tests
       -
         name: Release
-        uses: kubewarden/github-actions/policy-release@v3.1.10
+        uses: kubewarden/github-actions/policy-release@v3.1.11
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -62,4 +62,4 @@ jobs:
     steps:
       -
         name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v3.1.10
+        uses: kubewarden/github-actions/push-artifacthub@v3.1.11

--- a/.github/workflows/reusable-release-policy-swift.yml
+++ b/.github/workflows/reusable-release-policy-swift.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       -
         name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.1.10
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.1.11
       -
         uses: actions/checkout@v4
         with:
@@ -35,7 +35,7 @@ jobs:
         name: Check that artifacthub-pkg.yml is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub
-        uses: kubewarden/github-actions/check-artifacthub@v3.1.10
+        uses: kubewarden/github-actions/check-artifacthub@v3.1.11
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       -
@@ -67,7 +67,7 @@ jobs:
           make e2e-tests
       -
         name: Release
-        uses: kubewarden/github-actions/policy-release@v3.1.10
+        uses: kubewarden/github-actions/policy-release@v3.1.11
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -83,4 +83,4 @@ jobs:
     steps:
       -
         name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v3.1.10
+        uses: kubewarden/github-actions/push-artifacthub@v3.1.11

--- a/.github/workflows/reusable-test-policy-assemblyscript.yml
+++ b/.github/workflows/reusable-test-policy-assemblyscript.yml
@@ -41,14 +41,14 @@ jobs:
           fetch-depth: 0
       -
         name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v3.1.10
+        uses: kubewarden/github-actions/kwctl-installer@v3.1.11
       -
         id: calculate-version
         run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
       -
         name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthub@v3.1.10
+        uses: kubewarden/github-actions/check-artifacthub@v3.1.11
         with:
           version: ${{ steps.calculate-version.outputs.version }}
           check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then

--- a/.github/workflows/reusable-test-policy-go.yml
+++ b/.github/workflows/reusable-test-policy-go.yml
@@ -29,11 +29,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.1.10
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.1.11
       - name: Build and annotate policy
         with:
           generate-sbom: false
-        uses: kubewarden/github-actions/policy-build-go@v3.1.10
+        uses: kubewarden/github-actions/policy-build-go@v3.1.11
       - name: Run e2e tests
         run: make e2e-tests
 
@@ -58,12 +58,12 @@ jobs:
           # until https://github.com/actions/checkout/pull/579 is released
           fetch-depth: 0
       - name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v3.1.10
+        uses: kubewarden/github-actions/kwctl-installer@v3.1.11
       - id: calculate-version
         run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthub@v3.1.10
+        uses: kubewarden/github-actions/check-artifacthub@v3.1.11
         with:
           version: ${{ steps.calculate-version.outputs.version }}
           check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then

--- a/.github/workflows/reusable-test-policy-rego.yml
+++ b/.github/workflows/reusable-test-policy-rego.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
       -
         name: Install opa
-        uses: kubewarden/github-actions/opa-installer@v3.1.10
+        uses: kubewarden/github-actions/opa-installer@v3.1.11
       -
         name: Run unit tests
         run: make test
@@ -33,14 +33,14 @@ jobs:
           fetch-depth: 0
       -
         name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v3.1.10
+        uses: kubewarden/github-actions/kwctl-installer@v3.1.11
       -
         id: calculate-version
         run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
       -
         name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthub@v3.1.10
+        uses: kubewarden/github-actions/check-artifacthub@v3.1.11
         with:
           version: ${{ steps.calculate-version.outputs.version }}
           check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then

--- a/.github/workflows/reusable-test-policy-rust.yml
+++ b/.github/workflows/reusable-test-policy-rust.yml
@@ -37,14 +37,14 @@ jobs:
           fetch-depth: 0
       -
         name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v3.1.10
+        uses: kubewarden/github-actions/kwctl-installer@v3.1.11
       -
         id: calculate-version
         run: echo "version=$(sed  -n 's,^version = \"\(.*\)\",\1,p' Cargo.toml)" >> $GITHUB_OUTPUT
         shell: bash
       -
         name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthub@v3.1.10
+        uses: kubewarden/github-actions/check-artifacthub@v3.1.11
         with:
           version: ${{ steps.calculate-version.outputs.version }}
   check:

--- a/.github/workflows/reusable-test-policy-swift.yml
+++ b/.github/workflows/reusable-test-policy-swift.yml
@@ -31,14 +31,14 @@ jobs:
           fetch-depth: 0
       -
         name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v3.1.10
+        uses: kubewarden/github-actions/kwctl-installer@v3.1.11
       -
         id: calculate-version
         run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
       -
         name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthub@v3.1.10
+        uses: kubewarden/github-actions/check-artifacthub@v3.1.11
         with:
           version: ${{ steps.calculate-version.outputs.version }}
           check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then

--- a/kwctl-installer/action.yml
+++ b/kwctl-installer/action.yml
@@ -7,7 +7,7 @@ inputs:
   KWCTL_VERSION:
     description: "kwctl release to be installed"
     required: false
-    default: v1.7.0
+    default: v1.9.0-rc2
 runs:
   using: "composite"
   steps:

--- a/policy-gh-action-dependencies/action.yml
+++ b/policy-gh-action-dependencies/action.yml
@@ -11,7 +11,7 @@ runs:
       uses: sigstore/cosign-installer@v3
     -
       name: Install kwctl
-      uses: kubewarden/github-actions/kwctl-installer@v3.1.10
+      uses: kubewarden/github-actions/kwctl-installer@v3.1.11
     -
       name: Install bats
       uses: mig4/setup-bats@v1
@@ -19,4 +19,4 @@ runs:
         bats-version: 1.8.2
     -
       name: Install SBOM generator tool
-      uses: kubewarden/github-actions/sbom-generator-installer@v3.1.10
+      uses: kubewarden/github-actions/sbom-generator-installer@v3.1.11


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Consume kwctl v1.9.0-rc2 on the kwctl-installer.
This unblocks the release of the new raw policies.

This will be tagged v3.1.11 in main.
<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
