### PR TITLE
feat: run only lib tests for rust policies.

### DIFF
--- a/.github/workflows/reusable-test-policy-rust.yml
+++ b/.github/workflows/reusable-test-policy-rust.yml
@@ -73,6 +73,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
+          args: --lib
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

In the reusable workflow to perform basic validation in the Rust policies, we run all the tests in the policy. This can cause issues if the policy uses Rust to run e2e tests with kwctl. This commit updates the workflow to run only lib tests which are the policy unit tests.