### PR TITLE
rust policies move to wasm32 wasip1

### DIFF
--- a/.github/workflows/reusable-release-policy-assemblyscript.yml
+++ b/.github/workflows/reusable-release-policy-assemblyscript.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       -
         name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.1.19
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.1.20
       -
         uses: actions/checkout@v4
         with:
@@ -37,7 +37,7 @@ jobs:
         name: Check that artifacthub-pkg.yml is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub
-        uses: kubewarden/github-actions/check-artifacthub@v3.1.19
+        uses: kubewarden/github-actions/check-artifacthub@v3.1.20
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       -
@@ -68,7 +68,7 @@ jobs:
           make e2e-tests
       -
         name: Release
-        uses: kubewarden/github-actions/policy-release@v3.1.19
+        uses: kubewarden/github-actions/policy-release@v3.1.20
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -84,4 +84,4 @@ jobs:
     steps:
       -
         name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v3.1.19
+        uses: kubewarden/github-actions/push-artifacthub@v3.1.20

--- a/.github/workflows/reusable-release-policy-go.yml
+++ b/.github/workflows/reusable-release-policy-go.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       -
         name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.1.19
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.1.20
       -
         uses: actions/checkout@v4
         with:
@@ -35,19 +35,19 @@ jobs:
         name: Check that artifacthub-pkg.yml is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub
-        uses: kubewarden/github-actions/check-artifacthub@v3.1.19
+        uses: kubewarden/github-actions/check-artifacthub@v3.1.20
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       -
         name: Build and annotate policy
-        uses: kubewarden/github-actions/policy-build-go@v3.1.19
+        uses: kubewarden/github-actions/policy-build-go@v3.1.20
       -
         name: Run e2e tests
         run: |
           make e2e-tests
       -
         name: Release
-        uses: kubewarden/github-actions/policy-release@v3.1.19
+        uses: kubewarden/github-actions/policy-release@v3.1.20
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -63,4 +63,4 @@ jobs:
     steps:
       -
         name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v3.1.19
+        uses: kubewarden/github-actions/push-artifacthub@v3.1.20

--- a/.github/workflows/reusable-release-policy-rego.yml
+++ b/.github/workflows/reusable-release-policy-rego.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       -
         name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.1.19
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.1.20
       -
         uses: actions/checkout@v4
         with:
@@ -35,12 +35,12 @@ jobs:
         name: Check that artifacthub-pkg.yml is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub
-        uses: kubewarden/github-actions/check-artifacthub@v3.1.19
+        uses: kubewarden/github-actions/check-artifacthub@v3.1.20
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       -
         name: Install opa
-        uses: kubewarden/github-actions/opa-installer@v3.1.19
+        uses: kubewarden/github-actions/opa-installer@v3.1.20
       -
         uses: actions/checkout@v4
       -
@@ -57,7 +57,7 @@ jobs:
           make e2e-tests
       -
         name: Release
-        uses: kubewarden/github-actions/policy-release@v3.1.19
+        uses: kubewarden/github-actions/policy-release@v3.1.20
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -73,4 +73,4 @@ jobs:
     steps:
       -
         name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v3.1.19
+        uses: kubewarden/github-actions/push-artifacthub@v3.1.20

--- a/.github/workflows/reusable-release-policy-rust.yml
+++ b/.github/workflows/reusable-release-policy-rust.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       -
         name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.1.19
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.1.20
       -
         uses: actions/checkout@v4
         with:
@@ -34,19 +34,19 @@ jobs:
         name: Check that artifacthub-pkg.yml is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub
-        uses: kubewarden/github-actions/check-artifacthub@v3.1.19
+        uses: kubewarden/github-actions/check-artifacthub@v3.1.20
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       -
         name: Build and annotate policy
-        uses: kubewarden/github-actions/policy-build-rust@v3.1.19
+        uses: kubewarden/github-actions/policy-build-rust@v3.1.20
       -
         name: Run e2e tests
         run: |
           make e2e-tests
       -
         name: Release
-        uses: kubewarden/github-actions/policy-release@v3.1.19
+        uses: kubewarden/github-actions/policy-release@v3.1.20
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -62,4 +62,4 @@ jobs:
     steps:
       -
         name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v3.1.19
+        uses: kubewarden/github-actions/push-artifacthub@v3.1.20

--- a/.github/workflows/reusable-release-policy-swift.yml
+++ b/.github/workflows/reusable-release-policy-swift.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       -
         name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.1.19
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.1.20
       -
         uses: actions/checkout@v4
         with:
@@ -35,7 +35,7 @@ jobs:
         name: Check that artifacthub-pkg.yml is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub
-        uses: kubewarden/github-actions/check-artifacthub@v3.1.19
+        uses: kubewarden/github-actions/check-artifacthub@v3.1.20
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       -
@@ -67,7 +67,7 @@ jobs:
           make e2e-tests
       -
         name: Release
-        uses: kubewarden/github-actions/policy-release@v3.1.19
+        uses: kubewarden/github-actions/policy-release@v3.1.20
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -83,4 +83,4 @@ jobs:
     steps:
       -
         name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v3.1.19
+        uses: kubewarden/github-actions/push-artifacthub@v3.1.20

--- a/.github/workflows/reusable-test-policy-assemblyscript.yml
+++ b/.github/workflows/reusable-test-policy-assemblyscript.yml
@@ -41,14 +41,14 @@ jobs:
           fetch-depth: 0
       -
         name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v3.1.19
+        uses: kubewarden/github-actions/kwctl-installer@v3.1.20
       -
         id: calculate-version
         run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
       -
         name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthub@v3.1.19
+        uses: kubewarden/github-actions/check-artifacthub@v3.1.20
         with:
           version: ${{ steps.calculate-version.outputs.version }}
           check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then

--- a/.github/workflows/reusable-test-policy-go.yml
+++ b/.github/workflows/reusable-test-policy-go.yml
@@ -29,11 +29,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.1.19
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.1.20
       - name: Build and annotate policy
         with:
           generate-sbom: false
-        uses: kubewarden/github-actions/policy-build-go@v3.1.19
+        uses: kubewarden/github-actions/policy-build-go@v3.1.20
       - name: Run e2e tests
         run: make e2e-tests
 
@@ -58,12 +58,12 @@ jobs:
           # until https://github.com/actions/checkout/pull/579 is released
           fetch-depth: 0
       - name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v3.1.19
+        uses: kubewarden/github-actions/kwctl-installer@v3.1.20
       - id: calculate-version
         run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthub@v3.1.19
+        uses: kubewarden/github-actions/check-artifacthub@v3.1.20
         with:
           version: ${{ steps.calculate-version.outputs.version }}
           check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then

--- a/.github/workflows/reusable-test-policy-rego.yml
+++ b/.github/workflows/reusable-test-policy-rego.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
       -
         name: Install opa
-        uses: kubewarden/github-actions/opa-installer@v3.1.19
+        uses: kubewarden/github-actions/opa-installer@v3.1.20
       -
         name: Run unit tests
         run: make test
@@ -33,14 +33,14 @@ jobs:
           fetch-depth: 0
       -
         name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v3.1.19
+        uses: kubewarden/github-actions/kwctl-installer@v3.1.20
       -
         id: calculate-version
         run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
       -
         name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthub@v3.1.19
+        uses: kubewarden/github-actions/check-artifacthub@v3.1.20
         with:
           version: ${{ steps.calculate-version.outputs.version }}
           check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then

--- a/.github/workflows/reusable-test-policy-rust.yml
+++ b/.github/workflows/reusable-test-policy-rust.yml
@@ -37,14 +37,14 @@ jobs:
           fetch-depth: 0
       -
         name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v3.1.19
+        uses: kubewarden/github-actions/kwctl-installer@v3.1.20
       -
         id: calculate-version
         run: echo "version=$(sed  -n 's,^version = \"\(.*\)\",\1,p' Cargo.toml)" >> $GITHUB_OUTPUT
         shell: bash
       -
         name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthub@v3.1.19
+        uses: kubewarden/github-actions/check-artifacthub@v3.1.20
         with:
           version: ${{ steps.calculate-version.outputs.version }}
   check:

--- a/.github/workflows/reusable-test-policy-swift.yml
+++ b/.github/workflows/reusable-test-policy-swift.yml
@@ -31,14 +31,14 @@ jobs:
           fetch-depth: 0
       -
         name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v3.1.19
+        uses: kubewarden/github-actions/kwctl-installer@v3.1.20
       -
         id: calculate-version
         run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
       -
         name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthub@v3.1.19
+        uses: kubewarden/github-actions/check-artifacthub@v3.1.20
         with:
           version: ${{ steps.calculate-version.outputs.version }}
           check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then

--- a/policy-build-rust/action.yml
+++ b/policy-build-rust/action.yml
@@ -1,39 +1,33 @@
-name: 'kubewarden-policy-build-rust'
-description: 'Build a rust policy using rust'
+name: "kubewarden-policy-build-rust"
+description: "Build a rust policy using rust"
 branding:
-  icon: 'package'
-  color: 'blue'
+  icon: "package"
+  color: "blue"
 runs:
   using: "composite"
   steps:
-    -
-      name: Checkout code
+    - name: Checkout code
       uses: actions/checkout@v4
-    -
-      name: Prepare Rust environment
+    - name: Prepare Rust environment
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
         toolchain: stable
-        target: wasm32-wasi
-    -
-      name: Build Wasm module
+        target: wasm32-wasip1
+    - name: Build Wasm module
       uses: actions-rs/cargo@v1
       with:
         command: build
-        args: --target=wasm32-wasi --release
-    -
-      name: Rename Wasm module
+        args: --target=wasm32-wasip1 --release
+    - name: Rename Wasm module
       shell: bash
       run: |
-        cp target/wasm32-wasi/release/*.wasm policy.wasm
-    -
-      name: Annotate Wasm module
+        cp target/wasm32-wasip1/release/*.wasm policy.wasm
+    - name: Annotate Wasm module
       shell: bash
       run: |
         make annotated-policy.wasm
-    -
-      name: Generate the SBOM files
+    - name: Generate the SBOM files
       shell: bash
       run: |
         spdx-sbom-generator -f json
@@ -41,15 +35,13 @@ runs:
         # SBOM files should have "sbom" in the name due the CLO monitor
         # https://clomonitor.io/docs/topics/checks/#software-bill-of-materials-sbom
         mv bom-cargo.json policy-sbom.spdx.json
-    -
-      name: Sign BOM file
+    - name: Sign BOM file
       shell: bash
       run: |
         cosign sign-blob --yes --output-certificate policy-sbom.spdx.cert \
           --output-signature policy-sbom.spdx.sig \
           policy-sbom.spdx.json
-    -
-      name:  Upload policy SBOM files
+    - name: Upload policy SBOM files
       uses: actions/upload-artifact@v4
       with:
         name: policy-sbom

--- a/policy-gh-action-dependencies/action.yml
+++ b/policy-gh-action-dependencies/action.yml
@@ -9,12 +9,12 @@ runs:
     - name: Install cosign
       uses: sigstore/cosign-installer@v3
     - name: Install kwctl
-      uses: kubewarden/github-actions/kwctl-installer@v3.1.19
+      uses: kubewarden/github-actions/kwctl-installer@v3.1.20
     - name: Install bats
       uses: mig4/setup-bats@v1
       with:
         bats-version: 1.8.2
     - name: Install SBOM generator tool
-      uses: kubewarden/github-actions/sbom-generator-installer@v3.1.19
+      uses: kubewarden/github-actions/sbom-generator-installer@v3.1.20
     - name: Install SBOM generator tool
-      uses: kubewarden/github-actions/binaryen-installer@v3.1.19
+      uses: kubewarden/github-actions/binaryen-installer@v3.1.20


### PR DESCRIPTION
The `wasm32-wasi` target is deprecated and is has already been renamed `wasm32-wasip1`

See https://blog.rust-lang.org/2024/04/09/updates-to-rusts-wasi-targets.html

Also, prepare for 3.1.20 release of this action
