### PR TITLE
chore: update kwctl version

### DIFF
--- a/kwctl-installer/action.yml
+++ b/kwctl-installer/action.yml
@@ -7,7 +7,7 @@ inputs:
   KWCTL_VERSION:
     description: "kwctl release to be installed"
     required: false
-    default: v1.12.0
+    default: v1.14.0
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
We have policies which requires the latest kwctl version to access the new capability to fetch container image configuration. This is required to release the policies. Otherwise, the e2e tests run in the release process will fail.

## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #XXX

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, you can run the following commands:

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
