### PR TITLE
fix: increase Helm timeout

### DIFF
--- a/setup-kubewarden-cluster-action/action.yml
+++ b/setup-kubewarden-cluster-action/action.yml
@@ -99,11 +99,11 @@ runs:
       shell: bash
 
     - name: "Install Kubewarden CRDs"
-      run: helm upgrade --install --devel --wait --namespace kubewarden --create-namespace kubewarden-crds kubewarden/kubewarden-crds
+      run: helm upgrade --install --devel --wait --timeout 10m --namespace kubewarden --create-namespace kubewarden-crds kubewarden/kubewarden-crds
       shell: bash
     - name: "Install Kubewarden controller"
       run: |
-        helm upgrade --install --devel --wait \
+        helm upgrade --install --devel --wait --timeout 10m \
           --set image.repository=${{ inputs.controller-image-repository }} \
           --set image.tag=${{ inputs.controller-image-tag }} \
           --set policyServer.image.repository=${{ inputs.policy-server-repository }} \
@@ -113,7 +113,7 @@ runs:
       shell: bash
     - name: "Install Kubewarden defaults"
       run: |
-        helm upgrade --install --devel --wait \
+        helm upgrade --install --devel --wait --timeout 10m \
           --namespace kubewarden \
           kubewarden-defaults kubewarden/kubewarden-defaults
       shell: bash


### PR DESCRIPTION
## Description

Some E2E CI jobs are failing due the slowness of the installation process. This commit doubles the timeout to 10m.

Example of failing job: https://github.com/kubewarden/kubewarden-controller/actions/runs/10068249606/job/27833330861