### PR TITLE
feat: Run e2e tests on CI job for Rust policies 

### DIFF
--- a/.github/workflows/reusable-release-policy-assemblyscript.yml
+++ b/.github/workflows/reusable-release-policy-assemblyscript.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       -
         name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.3.2
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.3.3
       -
         uses: actions/checkout@v4
         with:
@@ -37,7 +37,7 @@ jobs:
         name: Check that artifacthub-pkg.yml is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub
-        uses: kubewarden/github-actions/check-artifacthub@v3.3.2
+        uses: kubewarden/github-actions/check-artifacthub@v3.3.3
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       -
@@ -68,7 +68,7 @@ jobs:
           make e2e-tests
       -
         name: Release
-        uses: kubewarden/github-actions/policy-release@v3.3.2
+        uses: kubewarden/github-actions/policy-release@v3.3.3
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -84,4 +84,4 @@ jobs:
     steps:
       -
         name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v3.3.2
+        uses: kubewarden/github-actions/push-artifacthub@v3.3.3

--- a/.github/workflows/reusable-release-policy-go.yml
+++ b/.github/workflows/reusable-release-policy-go.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       -
         name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.3.2
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.3.3
       -
         uses: actions/checkout@v4
         with:
@@ -35,19 +35,19 @@ jobs:
         name: Check that artifacthub-pkg.yml is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub
-        uses: kubewarden/github-actions/check-artifacthub@v3.3.2
+        uses: kubewarden/github-actions/check-artifacthub@v3.3.3
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       -
         name: Build and annotate policy
-        uses: kubewarden/github-actions/policy-build-go@v3.3.2
+        uses: kubewarden/github-actions/policy-build-go@v3.3.3
       -
         name: Run e2e tests
         run: |
           make e2e-tests
       -
         name: Release
-        uses: kubewarden/github-actions/policy-release@v3.3.2
+        uses: kubewarden/github-actions/policy-release@v3.3.3
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -63,4 +63,4 @@ jobs:
     steps:
       -
         name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v3.3.2
+        uses: kubewarden/github-actions/push-artifacthub@v3.3.3

--- a/.github/workflows/reusable-release-policy-rego.yml
+++ b/.github/workflows/reusable-release-policy-rego.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       -
         name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.3.2
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.3.3
       -
         uses: actions/checkout@v4
         with:
@@ -35,12 +35,12 @@ jobs:
         name: Check that artifacthub-pkg.yml is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub
-        uses: kubewarden/github-actions/check-artifacthub@v3.3.2
+        uses: kubewarden/github-actions/check-artifacthub@v3.3.3
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       -
         name: Install opa
-        uses: kubewarden/github-actions/opa-installer@v3.3.2
+        uses: kubewarden/github-actions/opa-installer@v3.3.3
       -
         uses: actions/checkout@v4
       -
@@ -57,7 +57,7 @@ jobs:
           make e2e-tests
       -
         name: Release
-        uses: kubewarden/github-actions/policy-release@v3.3.2
+        uses: kubewarden/github-actions/policy-release@v3.3.3
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -73,4 +73,4 @@ jobs:
     steps:
       -
         name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v3.3.2
+        uses: kubewarden/github-actions/push-artifacthub@v3.3.3

--- a/.github/workflows/reusable-release-policy-rust.yml
+++ b/.github/workflows/reusable-release-policy-rust.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       -
         name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.3.2
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.3.3
       -
         uses: actions/checkout@v4
         with:
@@ -34,19 +34,19 @@ jobs:
         name: Check that artifacthub-pkg.yml is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub
-        uses: kubewarden/github-actions/check-artifacthub@v3.3.2
+        uses: kubewarden/github-actions/check-artifacthub@v3.3.3
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       -
         name: Build and annotate policy
-        uses: kubewarden/github-actions/policy-build-rust@v3.3.2
+        uses: kubewarden/github-actions/policy-build-rust@v3.3.3
       -
         name: Run e2e tests
         run: |
           make e2e-tests
       -
         name: Release
-        uses: kubewarden/github-actions/policy-release@v3.3.2
+        uses: kubewarden/github-actions/policy-release@v3.3.3
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -62,4 +62,4 @@ jobs:
     steps:
       -
         name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v3.3.2
+        uses: kubewarden/github-actions/push-artifacthub@v3.3.3

--- a/.github/workflows/reusable-release-policy-swift.yml
+++ b/.github/workflows/reusable-release-policy-swift.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       -
         name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.3.2
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.3.3
       -
         uses: actions/checkout@v4
         with:
@@ -35,7 +35,7 @@ jobs:
         name: Check that artifacthub-pkg.yml is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub
-        uses: kubewarden/github-actions/check-artifacthub@v3.3.2
+        uses: kubewarden/github-actions/check-artifacthub@v3.3.3
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       -
@@ -67,7 +67,7 @@ jobs:
           make e2e-tests
       -
         name: Release
-        uses: kubewarden/github-actions/policy-release@v3.3.2
+        uses: kubewarden/github-actions/policy-release@v3.3.3
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -83,4 +83,4 @@ jobs:
     steps:
       -
         name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v3.3.2
+        uses: kubewarden/github-actions/push-artifacthub@v3.3.3

--- a/.github/workflows/reusable-test-policy-assemblyscript.yml
+++ b/.github/workflows/reusable-test-policy-assemblyscript.yml
@@ -41,14 +41,14 @@ jobs:
           fetch-depth: 0
       -
         name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v3.3.2
+        uses: kubewarden/github-actions/kwctl-installer@v3.3.3
       -
         id: calculate-version
         run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
       -
         name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthub@v3.3.2
+        uses: kubewarden/github-actions/check-artifacthub@v3.3.3
         with:
           version: ${{ steps.calculate-version.outputs.version }}
           check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then

--- a/.github/workflows/reusable-test-policy-go.yml
+++ b/.github/workflows/reusable-test-policy-go.yml
@@ -29,11 +29,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.3.2
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.3.3
       - name: Build and annotate policy
         with:
           generate-sbom: false
-        uses: kubewarden/github-actions/policy-build-go@v3.3.2
+        uses: kubewarden/github-actions/policy-build-go@v3.3.3
       - name: Run e2e tests
         run: make e2e-tests
 
@@ -58,12 +58,12 @@ jobs:
           # until https://github.com/actions/checkout/pull/579 is released
           fetch-depth: 0
       - name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v3.3.2
+        uses: kubewarden/github-actions/kwctl-installer@v3.3.3
       - id: calculate-version
         run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthub@v3.3.2
+        uses: kubewarden/github-actions/check-artifacthub@v3.3.3
         with:
           version: ${{ steps.calculate-version.outputs.version }}
           check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then

--- a/.github/workflows/reusable-test-policy-rego.yml
+++ b/.github/workflows/reusable-test-policy-rego.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
       -
         name: Install opa
-        uses: kubewarden/github-actions/opa-installer@v3.3.2
+        uses: kubewarden/github-actions/opa-installer@v3.3.3
       -
         name: Run unit tests
         run: make test
@@ -33,14 +33,14 @@ jobs:
           fetch-depth: 0
       -
         name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v3.3.2
+        uses: kubewarden/github-actions/kwctl-installer@v3.3.3
       -
         id: calculate-version
         run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
       -
         name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthub@v3.3.2
+        uses: kubewarden/github-actions/check-artifacthub@v3.3.3
         with:
           version: ${{ steps.calculate-version.outputs.version }}
           check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then

--- a/.github/workflows/reusable-test-policy-rust.yml
+++ b/.github/workflows/reusable-test-policy-rust.yml
@@ -73,6 +73,20 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
+  e2e-tests:
+    name: E2E testSuite
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.3.2
+      - name: Build and annotate policy
+        with:
+          generate-sbom: false
+        uses: kubewarden/github-actions/policy-build-rust@v3.3.2
+      - name: Run e2e tests
+        run: |
+          make e2e-tests
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable-test-policy-rust.yml
+++ b/.github/workflows/reusable-test-policy-rust.yml
@@ -35,12 +35,12 @@ jobs:
           # until https://github.com/actions/checkout/pull/579 is released
           fetch-depth: 0
       - name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v3.3.2
+        uses: kubewarden/github-actions/kwctl-installer@v3.3.3
       - id: calculate-version
         run: echo "version=$(sed  -n 's,^version = \"\(.*\)\",\1,p' Cargo.toml)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthub@v3.3.2
+        uses: kubewarden/github-actions/check-artifacthub@v3.3.3
         with:
           version: ${{ steps.calculate-version.outputs.version }}
   check:
@@ -75,11 +75,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.3.2
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.3.3
       - name: Build and annotate policy
         with:
           generate-sbom: false
-        uses: kubewarden/github-actions/policy-build-rust@v3.3.2
+        uses: kubewarden/github-actions/policy-build-rust@v3.3.3
       - name: Run e2e tests
         run: |
           make e2e-tests

--- a/.github/workflows/reusable-test-policy-rust.yml
+++ b/.github/workflows/reusable-test-policy-rust.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       artifacthub:
-        description: 'check artifacthub-pkg.yml for submission to ArtifactHub'
+        description: "check artifacthub-pkg.yml for submission to ArtifactHub"
         required: false
         type: boolean
         default: true
@@ -30,20 +30,16 @@ jobs:
     if: ${{ inputs.artifacthub }}
     runs-on: ubuntu-latest
     steps:
-      -
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           # until https://github.com/actions/checkout/pull/579 is released
           fetch-depth: 0
-      -
-        name: Install kwctl
+      - name: Install kwctl
         uses: kubewarden/github-actions/kwctl-installer@v3.3.2
-      -
-        id: calculate-version
+      - id: calculate-version
         run: echo "version=$(sed  -n 's,^version = \"\(.*\)\",\1,p' Cargo.toml)" >> $GITHUB_OUTPUT
         shell: bash
-      -
-        name: Check that artifacthub-pkg.yml is up-to-date
+      - name: Check that artifacthub-pkg.yml is up-to-date
         uses: kubewarden/github-actions/check-artifacthub@v3.3.2
         with:
           version: ${{ steps.calculate-version.outputs.version }}

--- a/.github/workflows/reusable-test-policy-swift.yml
+++ b/.github/workflows/reusable-test-policy-swift.yml
@@ -31,14 +31,14 @@ jobs:
           fetch-depth: 0
       -
         name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v3.3.2
+        uses: kubewarden/github-actions/kwctl-installer@v3.3.3
       -
         id: calculate-version
         run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
       -
         name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthub@v3.3.2
+        uses: kubewarden/github-actions/check-artifacthub@v3.3.3
         with:
           version: ${{ steps.calculate-version.outputs.version }}
           check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then

--- a/policy-build-rust/action.yml
+++ b/policy-build-rust/action.yml
@@ -3,6 +3,13 @@ description: "Build a rust policy using rust"
 branding:
   icon: "package"
   color: "blue"
+inputs:
+  generate-sbom:
+    required: false
+    description: "Generate and sign SBOM files"
+    # Boolean input should be compared with string
+    # until https://github.com/actions/runner/issues/2238 resolved
+    default: "true"
 runs:
   using: "composite"
   steps:
@@ -28,6 +35,7 @@ runs:
       run: |
         make annotated-policy.wasm
     - name: Generate the SBOM files
+      if: ${{ inputs.generate-sbom == 'true' }}
       shell: bash
       run: |
         spdx-sbom-generator -f json
@@ -36,12 +44,14 @@ runs:
         # https://clomonitor.io/docs/topics/checks/#software-bill-of-materials-sbom
         mv bom-cargo.json policy-sbom.spdx.json
     - name: Sign BOM file
+      if: ${{ inputs.generate-sbom == 'true' }}
       shell: bash
       run: |
         cosign sign-blob --yes --output-certificate policy-sbom.spdx.cert \
           --output-signature policy-sbom.spdx.sig \
           policy-sbom.spdx.json
     - name: Upload policy SBOM files
+      if: ${{ inputs.generate-sbom == 'true' }}
       uses: actions/upload-artifact@v4
       with:
         name: policy-sbom

--- a/policy-gh-action-dependencies/action.yml
+++ b/policy-gh-action-dependencies/action.yml
@@ -9,12 +9,12 @@ runs:
     - name: Install cosign
       uses: sigstore/cosign-installer@v3
     - name: Install kwctl
-      uses: kubewarden/github-actions/kwctl-installer@v3.3.2
+      uses: kubewarden/github-actions/kwctl-installer@v3.3.3
     - name: Install bats
       uses: mig4/setup-bats@v1.2.0
       with:
         bats-version: 1.11.0
     - name: Install SBOM generator tool
-      uses: kubewarden/github-actions/sbom-generator-installer@v3.3.2
+      uses: kubewarden/github-actions/sbom-generator-installer@v3.3.3
     - name: Install SBOM generator tool
-      uses: kubewarden/github-actions/binaryen-installer@v3.3.2
+      uses: kubewarden/github-actions/binaryen-installer@v3.3.3


### PR DESCRIPTION
## Description

Relates to https://github.com/kubewarden/kubewarden-controller/issues/855#issuecomment-2310453623.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

See CI for https://github.com/viccuad/verify-image-signatures/pull/1.
Example: https://github.com/viccuad/verify-image-signatures/actions/runs/10575780671/job/29300167919#step:5:56
(e2e tests run which is the important part, expected failure).

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

To be tagged as 3.3.3.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

The build of the policy prior to e2e tests takes 40s on a complex policy (such as verify-image-signatures). This happens in parallel with other CI jobs (unit tests, lints..).

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
