### PR TITLE
add go wasi policies

### DIFF
--- a/.github/workflows/reusable-release-policy-assemblyscript.yml
+++ b/.github/workflows/reusable-release-policy-assemblyscript.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       -
         name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.3.4
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.3.5
       -
         uses: actions/checkout@v4
         with:
@@ -37,7 +37,7 @@ jobs:
         name: Check that artifacthub-pkg.yml is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub
-        uses: kubewarden/github-actions/check-artifacthub@v3.3.4
+        uses: kubewarden/github-actions/check-artifacthub@v3.3.5
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       -
@@ -68,7 +68,7 @@ jobs:
           make e2e-tests
       -
         name: Release
-        uses: kubewarden/github-actions/policy-release@v3.3.4
+        uses: kubewarden/github-actions/policy-release@v3.3.5
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -84,4 +84,4 @@ jobs:
     steps:
       -
         name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v3.3.4
+        uses: kubewarden/github-actions/push-artifacthub@v3.3.5

--- a/.github/workflows/reusable-release-policy-go-wasi.yml
+++ b/.github/workflows/reusable-release-policy-go-wasi.yml
@@ -1,0 +1,58 @@
+name: Build and release a Kubewarden policy written in Go targeting KW WASI policy mode
+
+on:
+  workflow_call:
+    inputs:
+      oci-target:
+        type: string
+        required: true
+      artifacthub:
+        description: "check artifacthub-pkg.yml for submission to ArtifactHub"
+        required: false
+        type: boolean
+        default: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install dependencies
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.3.5
+      - uses: actions/checkout@v4
+        with:
+          # until https://github.com/actions/checkout/pull/579 is released
+          fetch-depth: 0
+      - id: calculate-version
+        # skip when releasing :latest from main, versions will not match
+        if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub
+        # obtain latest tag. Here it must be the current release tag
+        run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
+        shell: bash
+      - name: Check that artifacthub-pkg.yml is up-to-date
+        # skip when releasing :latest from main, versions will not match
+        if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub
+        uses: kubewarden/github-actions/check-artifacthub@v3.3.5
+        with:
+          version: ${{ steps.calculate-version.outputs.version }}
+      - name: Build and annotate policy
+        uses: kubewarden/github-actions/policy-build-go-wasi@v3.3.5
+      - name: Run e2e tests
+        run: |
+          make e2e-tests
+      - name: Release
+        uses: kubewarden/github-actions/policy-release@v3.3.5
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          oci-target: ${{ inputs.oci-target }}
+  push-artifacthub:
+    # skip when releasing :latest from main, versions will not match
+    if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub
+    needs: release
+    permissions:
+      # Give the default GITHUB_TOKEN write permission to commit and push the
+      # added or changed files to the repository.
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Push artifacthub files to artifacthub branch
+        uses: kubewarden/github-actions/push-artifacthub@v3.3.5

--- a/.github/workflows/reusable-release-policy-go.yml
+++ b/.github/workflows/reusable-release-policy-go.yml
@@ -7,7 +7,7 @@ on:
         type: string
         required: true
       artifacthub:
-        description: 'check artifacthub-pkg.yml for submission to ArtifactHub'
+        description: "check artifacthub-pkg.yml for submission to ArtifactHub"
         required: false
         type: boolean
         default: true
@@ -16,37 +16,30 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Install dependencies
+      - name: Install dependencies
         uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.3.4
-      -
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           # until https://github.com/actions/checkout/pull/579 is released
           fetch-depth: 0
-      -
-        id: calculate-version
+      - id: calculate-version
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub
         # obtain latest tag. Here it must be the current release tag
         run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
-      -
-        name: Check that artifacthub-pkg.yml is up-to-date
+      - name: Check that artifacthub-pkg.yml is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub
         uses: kubewarden/github-actions/check-artifacthub@v3.3.4
         with:
           version: ${{ steps.calculate-version.outputs.version }}
-      -
-        name: Build and annotate policy
-        uses: kubewarden/github-actions/policy-build-go@v3.3.4
-      -
-        name: Run e2e tests
+      - name: Build and annotate policy
+        uses: kubewarden/github-actions/policy-build-tinygo@v3.3.4
+      - name: Run e2e tests
         run: |
           make e2e-tests
-      -
-        name: Release
+      - name: Release
         uses: kubewarden/github-actions/policy-release@v3.3.4
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -61,6 +54,5 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Push artifacthub files to artifacthub branch
+      - name: Push artifacthub files to artifacthub branch
         uses: kubewarden/github-actions/push-artifacthub@v3.3.4

--- a/.github/workflows/reusable-release-policy-go.yml
+++ b/.github/workflows/reusable-release-policy-go.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.3.4
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.3.5
       - uses: actions/checkout@v4
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -31,16 +31,16 @@ jobs:
       - name: Check that artifacthub-pkg.yml is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub
-        uses: kubewarden/github-actions/check-artifacthub@v3.3.4
+        uses: kubewarden/github-actions/check-artifacthub@v3.3.5
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       - name: Build and annotate policy
-        uses: kubewarden/github-actions/policy-build-tinygo@v3.3.4
+        uses: kubewarden/github-actions/policy-build-tinygo@v3.3.5
       - name: Run e2e tests
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@v3.3.4
+        uses: kubewarden/github-actions/policy-release@v3.3.5
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -55,4 +55,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v3.3.4
+        uses: kubewarden/github-actions/push-artifacthub@v3.3.5

--- a/.github/workflows/reusable-release-policy-rego.yml
+++ b/.github/workflows/reusable-release-policy-rego.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       -
         name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.3.4
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.3.5
       -
         uses: actions/checkout@v4
         with:
@@ -35,12 +35,12 @@ jobs:
         name: Check that artifacthub-pkg.yml is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub
-        uses: kubewarden/github-actions/check-artifacthub@v3.3.4
+        uses: kubewarden/github-actions/check-artifacthub@v3.3.5
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       -
         name: Install opa
-        uses: kubewarden/github-actions/opa-installer@v3.3.4
+        uses: kubewarden/github-actions/opa-installer@v3.3.5
       -
         uses: actions/checkout@v4
       -
@@ -57,7 +57,7 @@ jobs:
           make e2e-tests
       -
         name: Release
-        uses: kubewarden/github-actions/policy-release@v3.3.4
+        uses: kubewarden/github-actions/policy-release@v3.3.5
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -73,4 +73,4 @@ jobs:
     steps:
       -
         name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v3.3.4
+        uses: kubewarden/github-actions/push-artifacthub@v3.3.5

--- a/.github/workflows/reusable-release-policy-rust.yml
+++ b/.github/workflows/reusable-release-policy-rust.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       -
         name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.3.4
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.3.5
       -
         uses: actions/checkout@v4
         with:
@@ -34,19 +34,19 @@ jobs:
         name: Check that artifacthub-pkg.yml is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub
-        uses: kubewarden/github-actions/check-artifacthub@v3.3.4
+        uses: kubewarden/github-actions/check-artifacthub@v3.3.5
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       -
         name: Build and annotate policy
-        uses: kubewarden/github-actions/policy-build-rust@v3.3.4
+        uses: kubewarden/github-actions/policy-build-rust@v3.3.5
       -
         name: Run e2e tests
         run: |
           make e2e-tests
       -
         name: Release
-        uses: kubewarden/github-actions/policy-release@v3.3.4
+        uses: kubewarden/github-actions/policy-release@v3.3.5
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -62,4 +62,4 @@ jobs:
     steps:
       -
         name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v3.3.4
+        uses: kubewarden/github-actions/push-artifacthub@v3.3.5

--- a/.github/workflows/reusable-release-policy-swift.yml
+++ b/.github/workflows/reusable-release-policy-swift.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       -
         name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.3.4
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.3.5
       -
         uses: actions/checkout@v4
         with:
@@ -35,7 +35,7 @@ jobs:
         name: Check that artifacthub-pkg.yml is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub
-        uses: kubewarden/github-actions/check-artifacthub@v3.3.4
+        uses: kubewarden/github-actions/check-artifacthub@v3.3.5
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       -
@@ -67,7 +67,7 @@ jobs:
           make e2e-tests
       -
         name: Release
-        uses: kubewarden/github-actions/policy-release@v3.3.4
+        uses: kubewarden/github-actions/policy-release@v3.3.5
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -83,4 +83,4 @@ jobs:
     steps:
       -
         name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v3.3.4
+        uses: kubewarden/github-actions/push-artifacthub@v3.3.5

--- a/.github/workflows/reusable-test-policy-assemblyscript.yml
+++ b/.github/workflows/reusable-test-policy-assemblyscript.yml
@@ -41,14 +41,14 @@ jobs:
           fetch-depth: 0
       -
         name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v3.3.4
+        uses: kubewarden/github-actions/kwctl-installer@v3.3.5
       -
         id: calculate-version
         run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
       -
         name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthub@v3.3.4
+        uses: kubewarden/github-actions/check-artifacthub@v3.3.5
         with:
           version: ${{ steps.calculate-version.outputs.version }}
           check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then

--- a/.github/workflows/reusable-test-policy-go-wasi.yml
+++ b/.github/workflows/reusable-test-policy-go-wasi.yml
@@ -1,0 +1,69 @@
+name: Tests and linters
+
+on:
+  workflow_call:
+    inputs:
+      artifacthub:
+        description: "check artifacthub-pkg.yml for submission to ArtifactHub"
+        required: false
+        type: boolean
+        default: true
+    secrets: {}
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.21"
+
+      - name: run Go unit tests
+        run: make test
+
+  e2e-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.3.5
+      - name: Build and annotate policy
+        with:
+          generate-sbom: false
+        uses: kubewarden/github-actions/policy-build-go-wasi@v3.3.5
+      - name: Run e2e tests
+        run: make e2e-tests
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.21"
+      - uses: actions/checkout@v4
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 # v6.1.0
+        with:
+          version: "latest"
+
+  check-artifacthub:
+    if: ${{ inputs.artifacthub }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # until https://github.com/actions/checkout/pull/579 is released
+          fetch-depth: 0
+      - name: Install kwctl
+        uses: kubewarden/github-actions/kwctl-installer@v3.3.5
+      - id: calculate-version
+        run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
+        shell: bash
+      - name: Check that artifacthub-pkg.yml is up-to-date
+        uses: kubewarden/github-actions/check-artifacthub@v3.3.5
+        with:
+          version: ${{ steps.calculate-version.outputs.version }}
+          check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then

--- a/.github/workflows/reusable-test-policy-go.yml
+++ b/.github/workflows/reusable-test-policy-go.yml
@@ -29,11 +29,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.3.4
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.3.5
       - name: Build and annotate policy
         with:
           generate-sbom: false
-        uses: kubewarden/github-actions/policy-build-tinygo@v3.3.4
+        uses: kubewarden/github-actions/policy-build-tinygo@v3.3.5
       - name: Run e2e tests
         run: make e2e-tests
 
@@ -58,12 +58,12 @@ jobs:
           # until https://github.com/actions/checkout/pull/579 is released
           fetch-depth: 0
       - name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v3.3.4
+        uses: kubewarden/github-actions/kwctl-installer@v3.3.5
       - id: calculate-version
         run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthub@v3.3.4
+        uses: kubewarden/github-actions/check-artifacthub@v3.3.5
         with:
           version: ${{ steps.calculate-version.outputs.version }}
           check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then

--- a/.github/workflows/reusable-test-policy-go.yml
+++ b/.github/workflows/reusable-test-policy-go.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Build and annotate policy
         with:
           generate-sbom: false
-        uses: kubewarden/github-actions/policy-build-go@v3.3.4
+        uses: kubewarden/github-actions/policy-build-tinygo@v3.3.4
       - name: Run e2e tests
         run: make e2e-tests
 

--- a/.github/workflows/reusable-test-policy-rego.yml
+++ b/.github/workflows/reusable-test-policy-rego.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
       -
         name: Install opa
-        uses: kubewarden/github-actions/opa-installer@v3.3.4
+        uses: kubewarden/github-actions/opa-installer@v3.3.5
       -
         name: Run unit tests
         run: make test
@@ -33,14 +33,14 @@ jobs:
           fetch-depth: 0
       -
         name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v3.3.4
+        uses: kubewarden/github-actions/kwctl-installer@v3.3.5
       -
         id: calculate-version
         run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
       -
         name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthub@v3.3.4
+        uses: kubewarden/github-actions/check-artifacthub@v3.3.5
         with:
           version: ${{ steps.calculate-version.outputs.version }}
           check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then

--- a/.github/workflows/reusable-test-policy-rust.yml
+++ b/.github/workflows/reusable-test-policy-rust.yml
@@ -35,12 +35,12 @@ jobs:
           # until https://github.com/actions/checkout/pull/579 is released
           fetch-depth: 0
       - name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v3.3.4
+        uses: kubewarden/github-actions/kwctl-installer@v3.3.5
       - id: calculate-version
         run: echo "version=$(sed  -n 's,^version = \"\(.*\)\",\1,p' Cargo.toml)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthub@v3.3.4
+        uses: kubewarden/github-actions/check-artifacthub@v3.3.5
         with:
           version: ${{ steps.calculate-version.outputs.version }}
   check:
@@ -75,11 +75,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.3.4
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.3.5
       - name: Build and annotate policy
         with:
           generate-sbom: false
-        uses: kubewarden/github-actions/policy-build-rust@v3.3.4
+        uses: kubewarden/github-actions/policy-build-rust@v3.3.5
       - name: Run e2e tests
         run: |
           make e2e-tests

--- a/.github/workflows/reusable-test-policy-swift.yml
+++ b/.github/workflows/reusable-test-policy-swift.yml
@@ -31,14 +31,14 @@ jobs:
           fetch-depth: 0
       -
         name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v3.3.4
+        uses: kubewarden/github-actions/kwctl-installer@v3.3.5
       -
         id: calculate-version
         run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
       -
         name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthub@v3.3.4
+        uses: kubewarden/github-actions/check-artifacthub@v3.3.5
         with:
           version: ${{ steps.calculate-version.outputs.version }}
           check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then

--- a/policy-build-go-wasi/action.yml
+++ b/policy-build-go-wasi/action.yml
@@ -1,0 +1,54 @@
+name: "kubewarden-policy-build-go-wasi"
+description: "Build a Go policy using the official Go compiler, targetting WASI"
+branding:
+  icon: "package"
+  color: "blue"
+inputs:
+  generate-sbom:
+    required: false
+    description: "Generate and sign SBOM files"
+    # Boolean input should be compared with string
+    # until https://github.com/actions/runner/issues/2238 resolved
+    default: "true"
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    - name: setup Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: "1.23"
+    - name: Build Wasm module
+      shell: bash
+      run: |
+        make policy.wasm
+    - name: Generate the SBOM files
+      if: ${{ inputs.generate-sbom == 'true' }}
+      shell: bash
+      run: |
+        spdx-sbom-generator -f json
+
+        # SBOM files should have "sbom" in the name due the CLO monitor
+        # https://clomonitor.io/docs/topics/checks/#software-bill-of-materials-sbom
+        mv bom-go-mod.json policy-sbom.spdx.json
+    - name: Annotate Wasm module
+      shell: bash
+      run: |
+        make annotated-policy.wasm
+    - name: Sign BOM file
+      if: ${{ inputs.generate-sbom == 'true' }}
+      shell: bash
+      run: |
+        cosign sign-blob --yes --output-certificate policy-sbom.spdx.cert \
+          --output-signature policy-sbom.spdx.sig \
+          policy-sbom.spdx.json
+    - name: Upload policy SBOM files
+      if: ${{ inputs.generate-sbom == 'true' }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: policy-sbom
+        path: |
+          policy-sbom.spdx.json
+          policy-sbom.spdx.cert
+          policy-sbom.spdx.sig

--- a/policy-build-tinygo/action.yml
+++ b/policy-build-tinygo/action.yml
@@ -1,4 +1,4 @@
-name: "kubewarden-policy-build-go"
+name: "kubewarden-policy-build-tinygo"
 description: "Build a Go policy using TinyGo"
 branding:
   icon: "package"

--- a/policy-gh-action-dependencies/action.yml
+++ b/policy-gh-action-dependencies/action.yml
@@ -9,12 +9,12 @@ runs:
     - name: Install cosign
       uses: sigstore/cosign-installer@v3
     - name: Install kwctl
-      uses: kubewarden/github-actions/kwctl-installer@v3.3.4
+      uses: kubewarden/github-actions/kwctl-installer@v3.3.5
     - name: Install bats
       uses: mig4/setup-bats@v1.2.0
       with:
         bats-version: 1.11.0
     - name: Install SBOM generator tool
-      uses: kubewarden/github-actions/sbom-generator-installer@v3.3.4
+      uses: kubewarden/github-actions/sbom-generator-installer@v3.3.5
     - name: Install SBOM generator tool
-      uses: kubewarden/github-actions/binaryen-installer@v3.3.4
+      uses: kubewarden/github-actions/binaryen-installer@v3.3.5


### PR DESCRIPTION
We just realized some Go-WASI policies are not signed with sigstore. That happens because we never uniformed our Go-WASI policies to use the same set of actions used by the TinyGo ones.

Now that we have go-wasi policies, we must be able to differentiate between policies built using waPC + TinyGo and the ones that are built using the official Go compiler and the WASI policy mode offered by Kubewarden.

The current tinygo policies will keep working as expected, without any change from us.

The Go-WASI policies will have to be changed to use the new reusable workflows defined by this PR.
