### PR TITLE
Flatten GH workflows into `.github/workflowsrelease.yml` for `slsactl` to work.

### DIFF
--- a/.github/workflows/reusable-release-policy-assemblyscript.yml
+++ b/.github/workflows/reusable-release-policy-assemblyscript.yml
@@ -25,8 +25,9 @@ jobs:
           # until https://github.com/actions/checkout/pull/579 is released
           fetch-depth: 0
       - id: calculate-version
+        if: ${{ ! startsWith(github.ref, 'refs/heads/') }}
         # obtain latest tag. Here it must be the current release tag
-        run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
+        run: echo "version=$(echo ${{ github.ref_name }} | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Check that artifacthub-pkg.yml is up-to-date
         # skip when releasing :latest from main, versions will not match

--- a/.github/workflows/reusable-release-policy-assemblyscript.yml
+++ b/.github/workflows/reusable-release-policy-assemblyscript.yml
@@ -60,6 +60,7 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
+          policy-version: ${{ steps.calculate-version.outputs.version }}
   push-artifacthub:
     # skip when releasing :latest from main, versions will not match
     if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub

--- a/.github/workflows/reusable-release-policy-assemblyscript.yml
+++ b/.github/workflows/reusable-release-policy-assemblyscript.yml
@@ -25,8 +25,6 @@ jobs:
           # until https://github.com/actions/checkout/pull/579 is released
           fetch-depth: 0
       - id: calculate-version
-        # skip when releasing :latest from main, versions will not match
-        if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub
         # obtain latest tag. Here it must be the current release tag
         run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash

--- a/.github/workflows/reusable-release-policy-assemblyscript.yml
+++ b/.github/workflows/reusable-release-policy-assemblyscript.yml
@@ -7,7 +7,7 @@ on:
         type: string
         required: true
       artifacthub:
-        description: 'check artifacthub-pkg.yml for submission to ArtifactHub'
+        description: "check artifacthub-pkg.yml for submission to ArtifactHub"
         required: false
         type: boolean
         default: true
@@ -18,56 +18,44 @@ jobs:
     env:
       NODE_VERSION: 14
     steps:
-      -
-        name: Install dependencies
+      - name: Install dependencies
         uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.3.5
-      -
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           # until https://github.com/actions/checkout/pull/579 is released
           fetch-depth: 0
-      -
-        id: calculate-version
+      - id: calculate-version
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub
         # obtain latest tag. Here it must be the current release tag
         run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
-      -
-        name: Check that artifacthub-pkg.yml is up-to-date
+      - name: Check that artifacthub-pkg.yml is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub
         uses: kubewarden/github-actions/check-artifacthub@v3.3.5
         with:
           version: ${{ steps.calculate-version.outputs.version }}
-      -
-        name: Setup node
+      - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: '${{ env.NODE_VERSION }}'
-      -
-        uses: actions/checkout@v4
-      -
-        name: Install npm
+          node-version: "${{ env.NODE_VERSION }}"
+      - uses: actions/checkout@v4
+      - name: Install npm
         run: npm install
-      -
-        name: Install npm dependencies
+      - name: Install npm dependencies
         run: |
           make deps
-      -
-        name: Build Wasm module
+      - name: Build Wasm module
         run: |
           make policy.wasm
-      -
-        name: annotate policy
+      - name: annotate policy
         run: |
           make annotated-policy.wasm
-      -
-        name: Run e2e tests
+      - name: Run e2e tests
         run: |
           make e2e-tests
-      -
-        name: Release
+      - name: Release
         uses: kubewarden/github-actions/policy-release@v3.3.5
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -82,6 +70,5 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Push artifacthub files to artifacthub branch
+      - name: Push artifacthub files to artifacthub branch
         uses: kubewarden/github-actions/push-artifacthub@v3.3.5

--- a/.github/workflows/reusable-release-policy-go-wasi.yml
+++ b/.github/workflows/reusable-release-policy-go-wasi.yml
@@ -23,8 +23,9 @@ jobs:
           # until https://github.com/actions/checkout/pull/579 is released
           fetch-depth: 0
       - id: calculate-version
+        if: ${{ ! startsWith(github.ref, 'refs/heads/') }}
         # obtain latest tag. Here it must be the current release tag
-        run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
+        run: echo "version=$(echo ${{ github.ref_name }} | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Check that artifacthub-pkg.yml is up-to-date
         # skip when releasing :latest from main, versions will not match

--- a/.github/workflows/reusable-release-policy-go-wasi.yml
+++ b/.github/workflows/reusable-release-policy-go-wasi.yml
@@ -23,8 +23,6 @@ jobs:
           # until https://github.com/actions/checkout/pull/579 is released
           fetch-depth: 0
       - id: calculate-version
-        # skip when releasing :latest from main, versions will not match
-        if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub
         # obtain latest tag. Here it must be the current release tag
         run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash

--- a/.github/workflows/reusable-release-policy-go-wasi.yml
+++ b/.github/workflows/reusable-release-policy-go-wasi.yml
@@ -44,6 +44,7 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
+          policy-version: ${{ steps.calculate-version.outputs.version }}
   push-artifacthub:
     # skip when releasing :latest from main, versions will not match
     if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub

--- a/.github/workflows/reusable-release-policy-go.yml
+++ b/.github/workflows/reusable-release-policy-go.yml
@@ -23,8 +23,9 @@ jobs:
           # until https://github.com/actions/checkout/pull/579 is released
           fetch-depth: 0
       - id: calculate-version
+        if: ${{ ! startsWith(github.ref, 'refs/heads/') }}
         # obtain latest tag. Here it must be the current release tag
-        run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
+        run: echo "version=$(echo ${{ github.ref_name }} | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Check that artifacthub-pkg.yml is up-to-date
         # skip when releasing :latest from main, versions will not match

--- a/.github/workflows/reusable-release-policy-go.yml
+++ b/.github/workflows/reusable-release-policy-go.yml
@@ -23,8 +23,6 @@ jobs:
           # until https://github.com/actions/checkout/pull/579 is released
           fetch-depth: 0
       - id: calculate-version
-        # skip when releasing :latest from main, versions will not match
-        if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub
         # obtain latest tag. Here it must be the current release tag
         run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash

--- a/.github/workflows/reusable-release-policy-go.yml
+++ b/.github/workflows/reusable-release-policy-go.yml
@@ -44,6 +44,7 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
+          policy-version: ${{ steps.calculate-version.outputs.version }}
   push-artifacthub:
     # skip when releasing :latest from main, versions will not match
     if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub

--- a/.github/workflows/reusable-release-policy-rego.yml
+++ b/.github/workflows/reusable-release-policy-rego.yml
@@ -11,6 +11,15 @@ on:
         required: false
         type: boolean
         default: true
+      policy-working-dir:
+        description: "working directory of the policy. Useful for repos with policies in folders"
+        required: false
+        type: string
+        default: .
+      policy-version:
+        description: "release version of the policy. Useful for repos with policies in folders"
+        required: false
+        type: string
 
 jobs:
   release:
@@ -23,27 +32,40 @@ jobs:
           # until https://github.com/actions/checkout/pull/579 is released
           fetch-depth: 0
       - id: calculate-version
-        # skip when releasing :latest from main, versions will not match
-        if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub
-        # obtain latest tag. Here it must be the current release tag
-        run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
+        if: ${{ inputs.artifacthub && ( ! startsWith(github.ref, 'refs/heads/') ) }}
+        # version may come from the policy-version var or from a tag.
+        # If neither is set, skip setting it, as the job is releasing :latest
+        # from main and must not update artifacthub-pkg.
         shell: bash
+        run: |
+          if [ "${{ inputs.policy-version }}" != "" ];then 
+            echo "version=${{ inputs.policy-version }}" >> $GITHUB_OUTPUT
+          else
+            echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
+          fi
       - name: Check that artifacthub-pkg.yml is up-to-date
         # skip when releasing :latest from main, versions will not match
-        if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub
+        if: ${{ inputs.artifacthub && ( ! startsWith(github.ref, 'refs/heads/') }}
         uses: kubewarden/github-actions/check-artifacthub@v3.3.5
         with:
           version: ${{ steps.calculate-version.outputs.version }}
+          policy-working-dir: ${{ inputs.policy-working-dir }}
       - name: Install opa
         uses: kubewarden/github-actions/opa-installer@v3.3.5
       - uses: actions/checkout@v4
       - name: Build policy
+        working-directory: ${{ inputs.policy-working-dir }}
+        shell: bash
         run: |
           make policy.wasm
       - name: Annotate policy
+        working-directory: ${{ inputs.policy-working-dir }}
+        shell: bash
         run: |
           make annotated-policy.wasm
       - name: Run e2e tests
+        working-directory: ${{ inputs.policy-working-dir }}
+        shell: bash
         run: |
           make e2e-tests
       - name: Release
@@ -51,9 +73,11 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
+          policy-working-dir: ${{ inputs.policy-working-dir }}
+          policy-version: ${{ inputs.policy-version }}
   push-artifacthub:
     # skip when releasing :latest from main, versions will not match
-    if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub
+    if: ${{ inputs.artifacthub && ( ! startsWith(github.ref, 'refs/heads/') ) }}
     needs: release
     permissions:
       # Give the default GITHUB_TOKEN write permission to commit and push the
@@ -63,3 +87,5 @@ jobs:
     steps:
       - name: Push artifacthub files to artifacthub branch
         uses: kubewarden/github-actions/push-artifacthub@v3.3.5
+        with:
+          policy-working-dir: ${{ inputs.policy-working-dir }}

--- a/.github/workflows/reusable-release-policy-rego.yml
+++ b/.github/workflows/reusable-release-policy-rego.yml
@@ -80,7 +80,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
           policy-working-dir: ${{ inputs.policy-working-dir }}
-          policy-version: ${{ inputs.policy-version }}
+          policy-version: ${{ steps.calculate-version.outputs.version }}
   push-artifacthub:
     # skip when releasing :latest from main, versions will not match
     if: ${{ inputs.artifacthub && ( ! startsWith(github.ref, 'refs/heads/') ) }}

--- a/.github/workflows/reusable-release-policy-rego.yml
+++ b/.github/workflows/reusable-release-policy-rego.yml
@@ -46,12 +46,12 @@ jobs:
       - name: Check that artifacthub-pkg.yml is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: ${{ inputs.artifacthub && ( ! startsWith(github.ref, 'refs/heads/') }}
-        uses: kubewarden/github-actions/check-artifacthub@v3.3.5
+        uses: viccuad/github-actions/check-artifacthub@main
         with:
           version: ${{ steps.calculate-version.outputs.version }}
           policy-working-dir: ${{ inputs.policy-working-dir }}
       - name: Install opa
-        uses: kubewarden/github-actions/opa-installer@v3.3.5
+        uses: viccuad/github-actions/opa-installer@main
       - uses: actions/checkout@v4
       - name: Build policy
         working-directory: ${{ inputs.policy-working-dir }}
@@ -69,7 +69,7 @@ jobs:
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@v3.3.5
+        uses: viccuad/github-actions/policy-release@main
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -86,6 +86,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v3.3.5
+        uses: viccuad/github-actions/push-artifacthub@main
         with:
           policy-working-dir: ${{ inputs.policy-working-dir }}

--- a/.github/workflows/reusable-release-policy-rego.yml
+++ b/.github/workflows/reusable-release-policy-rego.yml
@@ -17,7 +17,10 @@ on:
         type: string
         default: .
       policy-version:
-        description: "release version of the policy. Useful for repos with policies in folders"
+        description: |
+          Release version of the policy, without 'v' prefix. Optional.
+          Defaults to extracting the version from tag if tag present.
+          E.g: tag "v0.1.0", policy-version=0.1.0
         required: false
         type: string
 
@@ -39,8 +42,11 @@ jobs:
         shell: bash
         run: |
           if [ "${{ inputs.policy-version }}" != "" ];then 
+            # If present, it means we are dealing with tags in the form of PolicyName/v0.1.0
+            # Transform the passed policy-version=0.1.0 into version=v0.1.0
             echo "version=${{ inputs.policy-version }}" >> $GITHUB_OUTPUT
           else
+            # We are dealing with normal tags. Use the full tag, after cutting the `v` prefix
             echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
           fi
       - name: Check that artifacthub-pkg.yml is up-to-date

--- a/.github/workflows/reusable-release-policy-rego.yml
+++ b/.github/workflows/reusable-release-policy-rego.yml
@@ -35,10 +35,6 @@ jobs:
           # until https://github.com/actions/checkout/pull/579 is released
           fetch-depth: 0
       - id: calculate-version
-        if: ${{ inputs.artifacthub && ( ! startsWith(github.ref, 'refs/heads/') ) }}
-        # version may come from the policy-version var or from a tag.
-        # If neither is set, skip setting it, as the job is releasing :latest
-        # from main and must not update artifacthub-pkg.
         shell: bash
         run: |
           if [ "${{ inputs.policy-version }}" != "" ];then 

--- a/.github/workflows/reusable-release-policy-rego.yml
+++ b/.github/workflows/reusable-release-policy-rego.yml
@@ -47,7 +47,7 @@ jobs:
           fi
       - name: Check that artifacthub-pkg.yml is up-to-date
         # skip when releasing :latest from main, versions will not match
-        if: ${{ inputs.artifacthub && ( ! startsWith(github.ref, 'refs/heads/') }}
+        if: ${{ inputs.artifacthub && ( ! startsWith(github.ref, 'refs/heads/') ) }}
         uses: viccuad/github-actions/check-artifacthub@main
         with:
           version: ${{ steps.calculate-version.outputs.version }}

--- a/.github/workflows/reusable-release-policy-rego.yml
+++ b/.github/workflows/reusable-release-policy-rego.yml
@@ -7,7 +7,7 @@ on:
         type: string
         required: true
       artifacthub:
-        description: 'check artifacthub-pkg.yml for submission to ArtifactHub'
+        description: "check artifacthub-pkg.yml for submission to ArtifactHub"
         required: false
         type: boolean
         default: true
@@ -16,47 +16,37 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Install dependencies
+      - name: Install dependencies
         uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.3.5
-      -
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           # until https://github.com/actions/checkout/pull/579 is released
           fetch-depth: 0
-      -
-        id: calculate-version
+      - id: calculate-version
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub
         # obtain latest tag. Here it must be the current release tag
         run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
-      -
-        name: Check that artifacthub-pkg.yml is up-to-date
+      - name: Check that artifacthub-pkg.yml is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub
         uses: kubewarden/github-actions/check-artifacthub@v3.3.5
         with:
           version: ${{ steps.calculate-version.outputs.version }}
-      -
-        name: Install opa
+      - name: Install opa
         uses: kubewarden/github-actions/opa-installer@v3.3.5
-      -
-        uses: actions/checkout@v4
-      -
-        name: Build policy
+      - uses: actions/checkout@v4
+      - name: Build policy
         run: |
           make policy.wasm
-      -
-        name: Annotate policy
+      - name: Annotate policy
         run: |
           make annotated-policy.wasm
-      -
-        name: Run e2e tests
+      - name: Run e2e tests
         run: |
           make e2e-tests
-      -
-        name: Release
+      - name: Release
         uses: kubewarden/github-actions/policy-release@v3.3.5
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -71,6 +61,5 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Push artifacthub files to artifacthub branch
+      - name: Push artifacthub files to artifacthub branch
         uses: kubewarden/github-actions/push-artifacthub@v3.3.5

--- a/.github/workflows/reusable-release-policy-rego.yml
+++ b/.github/workflows/reusable-release-policy-rego.yml
@@ -35,6 +35,7 @@ jobs:
           # until https://github.com/actions/checkout/pull/579 is released
           fetch-depth: 0
       - id: calculate-version
+        if: ${{ ! startsWith(github.ref, 'refs/heads/') }}
         shell: bash
         run: |
           if [ "${{ inputs.policy-version }}" != "" ];then 
@@ -43,7 +44,7 @@ jobs:
             echo "version=${{ inputs.policy-version }}" >> $GITHUB_OUTPUT
           else
             # We are dealing with normal tags. Use the full tag, after cutting the `v` prefix
-            echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
+            echo "version=$(echo ${{ github.ref_name }} | cut -c2-)" >> $GITHUB_OUTPUT
           fi
       - name: Check that artifacthub-pkg.yml is up-to-date
         # skip when releasing :latest from main, versions will not match

--- a/.github/workflows/reusable-release-policy-rust.yml
+++ b/.github/workflows/reusable-release-policy-rust.yml
@@ -24,7 +24,8 @@ jobs:
           fetch-depth: 0
       - id: calculate-version
         # obtain latest tag. Here it must be the current release tag
-        run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
+        if: ${{ ! startsWith(github.ref, 'refs/heads/') }}
+        run: echo "version=$(echo ${{ github.ref_name }} | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Check that artifacthub-pkg.yml is up-to-date
         # skip when releasing :latest from main, versions will not match

--- a/.github/workflows/reusable-release-policy-rust.yml
+++ b/.github/workflows/reusable-release-policy-rust.yml
@@ -23,8 +23,7 @@ jobs:
           # until https://github.com/actions/checkout/pull/579 is released
           fetch-depth: 0
       - id: calculate-version
-        # skip when releasing :latest from main, versions will not match
-        if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub
+        # obtain latest tag. Here it must be the current release tag
         run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Check that artifacthub-pkg.yml is up-to-date

--- a/.github/workflows/reusable-release-policy-rust.yml
+++ b/.github/workflows/reusable-release-policy-rust.yml
@@ -7,7 +7,7 @@ on:
         type: string
         required: true
       artifacthub:
-        description: 'check artifacthub-pkg.yml for submission to ArtifactHub'
+        description: "check artifacthub-pkg.yml for submission to ArtifactHub"
         required: false
         type: boolean
         default: true
@@ -16,36 +16,29 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Install dependencies
+      - name: Install dependencies
         uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.3.5
-      -
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           # until https://github.com/actions/checkout/pull/579 is released
           fetch-depth: 0
-      -
-        id: calculate-version
+      - id: calculate-version
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub
         run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
-      -
-        name: Check that artifacthub-pkg.yml is up-to-date
+      - name: Check that artifacthub-pkg.yml is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub
         uses: kubewarden/github-actions/check-artifacthub@v3.3.5
         with:
           version: ${{ steps.calculate-version.outputs.version }}
-      -
-        name: Build and annotate policy
+      - name: Build and annotate policy
         uses: kubewarden/github-actions/policy-build-rust@v3.3.5
-      -
-        name: Run e2e tests
+      - name: Run e2e tests
         run: |
           make e2e-tests
-      -
-        name: Release
+      - name: Release
         uses: kubewarden/github-actions/policy-release@v3.3.5
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -60,6 +53,5 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Push artifacthub files to artifacthub branch
+      - name: Push artifacthub files to artifacthub branch
         uses: kubewarden/github-actions/push-artifacthub@v3.3.5

--- a/.github/workflows/reusable-release-policy-rust.yml
+++ b/.github/workflows/reusable-release-policy-rust.yml
@@ -43,6 +43,7 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
+          policy-version: ${{ steps.calculate-version.outputs.version }}
   push-artifacthub:
     # skip when releasing :latest from main, versions will not match
     if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub

--- a/.github/workflows/reusable-release-policy-swift.yml
+++ b/.github/workflows/reusable-release-policy-swift.yml
@@ -23,8 +23,9 @@ jobs:
           # until https://github.com/actions/checkout/pull/579 is released
           fetch-depth: 0
       - id: calculate-version
+        if: ${{ ! startsWith(github.ref, 'refs/heads/') }}
         # obtain latest tag. Here it must be the current release tag
-        run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
+        run: echo "version=$(echo ${{ github.ref_name }} | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Check that artifacthub-pkg.yml is up-to-date
         # skip when releasing :latest from main, versions will not match

--- a/.github/workflows/reusable-release-policy-swift.yml
+++ b/.github/workflows/reusable-release-policy-swift.yml
@@ -61,6 +61,7 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
+          policy-version: ${{ steps.calculate-version.outputs.version }}
   push-artifacthub:
     # skip when releasing :latest from main, versions will not match
     if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub

--- a/.github/workflows/reusable-release-policy-swift.yml
+++ b/.github/workflows/reusable-release-policy-swift.yml
@@ -23,8 +23,6 @@ jobs:
           # until https://github.com/actions/checkout/pull/579 is released
           fetch-depth: 0
       - id: calculate-version
-        # skip when releasing :latest from main, versions will not match
-        if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub
         # obtain latest tag. Here it must be the current release tag
         run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash

--- a/.github/workflows/reusable-release-policy-swift.yml
+++ b/.github/workflows/reusable-release-policy-swift.yml
@@ -7,7 +7,7 @@ on:
         type: string
         required: true
       artifacthub:
-        description: 'check artifacthub-pkg.yml for submission to ArtifactHub'
+        description: "check artifacthub-pkg.yml for submission to ArtifactHub"
         required: false
         type: boolean
         default: true
@@ -16,57 +16,47 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Install dependencies
+      - name: Install dependencies
         uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.3.5
-      -
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           # until https://github.com/actions/checkout/pull/579 is released
           fetch-depth: 0
-      -
-        id: calculate-version
+      - id: calculate-version
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub
         # obtain latest tag. Here it must be the current release tag
         run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
-      -
-        name: Check that artifacthub-pkg.yml is up-to-date
+      - name: Check that artifacthub-pkg.yml is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub
         uses: kubewarden/github-actions/check-artifacthub@v3.3.5
         with:
           version: ${{ steps.calculate-version.outputs.version }}
-      -
-        name: install wasm-strip
+      - name: install wasm-strip
         run: |
           export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true
           sudo apt-get -q update
           sudo apt-get -q install -y wabt binaryen
-      -
-        name: Build release
+      - name: Build release
         uses: swiftwasm/swiftwasm-action@v5.9
         with:
           shell-action: swift build -c release --triple wasm32-unknown-wasi --build-path build
-      -
-        name: optimize policy
+      - name: optimize policy
         run: |
           # need to fix file permissions because of some issue with Swift Foundation and filesystem
           sudo chmod 777 build/wasm32-unknown-wasi/release/Policy.wasm
           wasm-strip build/wasm32-unknown-wasi/release/Policy.wasm
           wasm-opt -Os build/wasm32-unknown-wasi/release/Policy.wasm -o policy.wasm
 
-      -
-        name: Annotate Wasm module
+      - name: Annotate Wasm module
         run: |
           make annotated-policy.wasm
-      -
-        name: Run e2e tests
+      - name: Run e2e tests
         run: |
           make e2e-tests
-      -
-        name: Release
+      - name: Release
         uses: kubewarden/github-actions/policy-release@v3.3.5
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -81,6 +71,5 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Push artifacthub files to artifacthub branch
+      - name: Push artifacthub files to artifacthub branch
         uses: kubewarden/github-actions/push-artifacthub@v3.3.5

--- a/.github/workflows/reusable-test-policy-assemblyscript.yml
+++ b/.github/workflows/reusable-test-policy-assemblyscript.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       artifacthub:
-        description: 'check artifacthub-pkg.yml for submission to ArtifactHub'
+        description: "check artifacthub-pkg.yml for submission to ArtifactHub"
         required: false
         type: boolean
         default: true
@@ -16,38 +16,30 @@ jobs:
     env:
       NODE_VERSION: 14
     steps:
-      -
-        uses: actions/checkout@v4
-      -
-        name: Setup node
+      - uses: actions/checkout@v4
+      - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: '${{ env.NODE_VERSION }}'
-      -
-        name: Install npm
+          node-version: "${{ env.NODE_VERSION }}"
+      - name: Install npm
         run: npm install
-      -
-        name: Run unit-tests
+      - name: Run unit-tests
         run: |
           make test
   check-artifacthub:
     if: ${{ inputs.artifacthub }}
     runs-on: ubuntu-latest
     steps:
-      -
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           # until https://github.com/actions/checkout/pull/579 is released
           fetch-depth: 0
-      -
-        name: Install kwctl
+      - name: Install kwctl
         uses: kubewarden/github-actions/kwctl-installer@v3.3.5
-      -
-        id: calculate-version
+      - id: calculate-version
         run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
-      -
-        name: Check that artifacthub-pkg.yml is up-to-date
+      - name: Check that artifacthub-pkg.yml is up-to-date
         uses: kubewarden/github-actions/check-artifacthub@v3.3.5
         with:
           version: ${{ steps.calculate-version.outputs.version }}

--- a/.github/workflows/reusable-test-policy-assemblyscript.yml
+++ b/.github/workflows/reusable-test-policy-assemblyscript.yml
@@ -37,7 +37,8 @@ jobs:
       - name: Install kwctl
         uses: kubewarden/github-actions/kwctl-installer@v3.3.5
       - id: calculate-version
-        run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
+        if: ${{ ! startsWith(github.ref, 'refs/heads/') }}
+        run: echo "version=$(echo ${{ github.ref_name }} | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Check that artifacthub-pkg.yml is up-to-date
         uses: kubewarden/github-actions/check-artifacthub@v3.3.5

--- a/.github/workflows/reusable-test-policy-go-wasi.yml
+++ b/.github/workflows/reusable-test-policy-go-wasi.yml
@@ -60,7 +60,8 @@ jobs:
       - name: Install kwctl
         uses: kubewarden/github-actions/kwctl-installer@v3.3.5
       - id: calculate-version
-        run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
+        if: ${{ ! startsWith(github.ref, 'refs/heads/') }}
+        run: echo "version=$(echo ${{ github.ref_name }} | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Check that artifacthub-pkg.yml is up-to-date
         uses: kubewarden/github-actions/check-artifacthub@v3.3.5

--- a/.github/workflows/reusable-test-policy-go.yml
+++ b/.github/workflows/reusable-test-policy-go.yml
@@ -60,7 +60,8 @@ jobs:
       - name: Install kwctl
         uses: kubewarden/github-actions/kwctl-installer@v3.3.5
       - id: calculate-version
-        run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
+        if: ${{ ! startsWith(github.ref, 'refs/heads/') }}
+        run: echo "version=$(echo ${{ github.ref_name }} | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Check that artifacthub-pkg.yml is up-to-date
         uses: kubewarden/github-actions/check-artifacthub@v3.3.5

--- a/.github/workflows/reusable-test-policy-rego.yml
+++ b/.github/workflows/reusable-test-policy-rego.yml
@@ -14,7 +14,10 @@ on:
         type: string
         default: .
       policy-version:
-        description: "release version of the policy. Useful for repos with policies in folders, and only on release jobs"
+        description: |
+          Release version of the policy, without 'v' prefix. Optional.
+          Defaults to extracting the version from tag if tag present.
+          E.g: tag "v0.1.0", policy-version=0.1.0
         required: false
         type: string
     secrets: {}
@@ -44,8 +47,11 @@ jobs:
         shell: bash
         run: |
           if [ "${{ inputs.policy-version }}" != "" ];then 
+            # If present, it means we are dealing with tags in the form of PolicyName/v0.1.0
+            # Transform the passed policy-version=0.1.0 into version=v0.1.0
             echo "version=${{ inputs.policy-version }}" >> $GITHUB_OUTPUT
           else
+            # We are dealing with normal tags. Use the full tag, after cutting the `v` prefix
             echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
           fi
       - name: Check that artifacthub-pkg.yml is up-to-date

--- a/.github/workflows/reusable-test-policy-rego.yml
+++ b/.github/workflows/reusable-test-policy-rego.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install opa
-        uses: kubewarden/github-actions/opa-installer@v3.3.5
+        uses: viccuad/github-actions/opa-installer@main
       - name: Run unit tests
         working-directory: ${{ inputs.policy-working-dir }}
         run: make test
@@ -51,7 +51,7 @@ jobs:
       - name: Check that artifacthub-pkg.yml is up-to-date
         # only makes sense to run this check if artifacthub-pkg.yml has been
         # updated for an upcoming release.
-        uses: kubewarden/github-actions/check-artifacthub@v3.3.5
+        uses: viccuad/github-actions/check-artifacthub@main
         with:
           version: ${{ steps.calculate-version.outputs.version }}
           check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then

--- a/.github/workflows/reusable-test-policy-rego.yml
+++ b/.github/workflows/reusable-test-policy-rego.yml
@@ -8,6 +8,15 @@ on:
         required: false
         type: boolean
         default: true
+      policy-working-dir:
+        description: "working directory of the policy. Useful for repos with policies in folders"
+        required: false
+        type: string
+        default: .
+      policy-version:
+        description: "release version of the policy. Useful for repos with policies in folders, and only on release jobs"
+        required: false
+        type: string
     secrets: {}
 
 jobs:
@@ -18,8 +27,10 @@ jobs:
       - name: Install opa
         uses: kubewarden/github-actions/opa-installer@v3.3.5
       - name: Run unit tests
+        working-directory: ${{ inputs.policy-working-dir }}
         run: make test
   check-artifacthub:
+    # construct updated artifacthub-pkg.yml and check it contains the correct values
     if: ${{ inputs.artifacthub }}
     runs-on: ubuntu-latest
     steps:
@@ -30,10 +41,18 @@ jobs:
       - name: Install kwctl
         uses: kubewarden/github-actions/kwctl-installer@v3.3.5
       - id: calculate-version
-        run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
+        run: |
+          if [ "${{ inputs.policy-version }}" != "" ];then 
+            echo "version=${{ inputs.policy-version }}" >> $GITHUB_OUTPUT
+          else
+            echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
+          fi
       - name: Check that artifacthub-pkg.yml is up-to-date
+        # only makes sense to run this check if artifacthub-pkg.yml has been
+        # updated for an upcoming release.
         uses: kubewarden/github-actions/check-artifacthub@v3.3.5
         with:
           version: ${{ steps.calculate-version.outputs.version }}
           check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then
+          policy-working-dir: ${{ inputs.policy-working-dir }}

--- a/.github/workflows/reusable-test-policy-rego.yml
+++ b/.github/workflows/reusable-test-policy-rego.yml
@@ -44,6 +44,7 @@ jobs:
       - name: Install kwctl
         uses: kubewarden/github-actions/kwctl-installer@v3.3.5
       - id: calculate-version
+        if: ${{ ! startsWith(github.ref, 'refs/heads/') }}
         shell: bash
         run: |
           if [ "${{ inputs.policy-version }}" != "" ];then 
@@ -52,7 +53,7 @@ jobs:
             echo "version=${{ inputs.policy-version }}" >> $GITHUB_OUTPUT
           else
             # We are dealing with normal tags. Use the full tag, after cutting the `v` prefix
-            echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
+            echo "version=$(echo ${{ github.ref_name }} | cut -c2-)" >> $GITHUB_OUTPUT
           fi
       - name: Check that artifacthub-pkg.yml is up-to-date
         # only makes sense to run this check if artifacthub-pkg.yml has been

--- a/.github/workflows/reusable-test-policy-rego.yml
+++ b/.github/workflows/reusable-test-policy-rego.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       artifacthub:
-        description: 'check artifacthub-pkg.yml for submission to ArtifactHub'
+        description: "check artifacthub-pkg.yml for submission to ArtifactHub"
         required: false
         type: boolean
         default: true
@@ -14,32 +14,25 @@ jobs:
   unit-tests:
     runs-on: ubuntu-latest
     steps:
-      -
-        uses: actions/checkout@v4
-      -
-        name: Install opa
+      - uses: actions/checkout@v4
+      - name: Install opa
         uses: kubewarden/github-actions/opa-installer@v3.3.5
-      -
-        name: Run unit tests
+      - name: Run unit tests
         run: make test
   check-artifacthub:
     if: ${{ inputs.artifacthub }}
     runs-on: ubuntu-latest
     steps:
-      -
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           # until https://github.com/actions/checkout/pull/579 is released
           fetch-depth: 0
-      -
-        name: Install kwctl
+      - name: Install kwctl
         uses: kubewarden/github-actions/kwctl-installer@v3.3.5
-      -
-        id: calculate-version
+      - id: calculate-version
         run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
-      -
-        name: Check that artifacthub-pkg.yml is up-to-date
+      - name: Check that artifacthub-pkg.yml is up-to-date
         uses: kubewarden/github-actions/check-artifacthub@v3.3.5
         with:
           version: ${{ steps.calculate-version.outputs.version }}

--- a/.github/workflows/reusable-test-policy-rust.yml
+++ b/.github/workflows/reusable-test-policy-rust.yml
@@ -40,7 +40,7 @@ jobs:
         run: echo "version=$(sed  -n 's,^version = \"\(.*\)\",\1,p' Cargo.toml)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthub@v3.3.5
+        uses: viccuad/github-actions/check-artifacthub@main
         with:
           version: ${{ steps.calculate-version.outputs.version }}
   check:

--- a/.github/workflows/reusable-test-policy-rust.yml
+++ b/.github/workflows/reusable-test-policy-rust.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Install kwctl
         uses: kubewarden/github-actions/kwctl-installer@v3.3.5
       - id: calculate-version
+        if: ${{ ! startsWith(github.ref, 'refs/heads/') }}
         run: echo "version=$(sed  -n 's,^version = \"\(.*\)\",\1,p' Cargo.toml)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Check that artifacthub-pkg.yml is up-to-date

--- a/.github/workflows/reusable-test-policy-swift.yml
+++ b/.github/workflows/reusable-test-policy-swift.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       artifacthub:
-        description: 'check artifacthub-pkg.yml for submission to ArtifactHub'
+        description: "check artifacthub-pkg.yml for submission to ArtifactHub"
         required: false
         type: boolean
         default: true
@@ -24,20 +24,16 @@ jobs:
     if: ${{ inputs.artifacthub }}
     runs-on: ubuntu-latest
     steps:
-      -
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           # until https://github.com/actions/checkout/pull/579 is released
           fetch-depth: 0
-      -
-        name: Install kwctl
+      - name: Install kwctl
         uses: kubewarden/github-actions/kwctl-installer@v3.3.5
-      -
-        id: calculate-version
+      - id: calculate-version
         run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
-      -
-        name: Check that artifacthub-pkg.yml is up-to-date
+      - name: Check that artifacthub-pkg.yml is up-to-date
         uses: kubewarden/github-actions/check-artifacthub@v3.3.5
         with:
           version: ${{ steps.calculate-version.outputs.version }}

--- a/.github/workflows/reusable-test-policy-swift.yml
+++ b/.github/workflows/reusable-test-policy-swift.yml
@@ -31,7 +31,8 @@ jobs:
       - name: Install kwctl
         uses: kubewarden/github-actions/kwctl-installer@v3.3.5
       - id: calculate-version
-        run: echo "version=$(git describe --tags --abbrev=0 | cut -c2-)" >> $GITHUB_OUTPUT
+        if: ${{ ! startsWith(github.ref, 'refs/heads/') }}
+        run: echo "version=$(echo ${{ github.ref_name }} | cut -c2-)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Check that artifacthub-pkg.yml is up-to-date
         uses: kubewarden/github-actions/check-artifacthub@v3.3.5

--- a/check-artifacthub/action.yml
+++ b/check-artifacthub/action.yml
@@ -5,28 +5,33 @@ branding:
   color: "blue"
 inputs:
   version:
-    description: "version string to use in artifacthub-plg.yml"
+    description: "version string to use when constructing artifacthub-pkg.yml"
     required: true
     type: string
   check_version:
-    description: "check version string in comparison"
+    description: "wether to check that the image, url, etc, contain inputs.version"
     default: true
     type: bool
+  policy-working-dir:
+    description: "working directory of the policy. Useful for repos with policies in folders"
+    required: false
+    type: string
+    default: .
 runs:
   using: "composite"
   steps:
     - name: Checkout code
       uses: actions/checkout@v4
-
     - name: Check that artifacthub-pkg.yml is up-to-date
       shell: bash
+      working-directory: ${{ inputs.policy-working-dir }}
       run: |
         rm artifacthub-pkg.yml # force recreation of file
         make artifacthub-pkg.yml VERSION=${{ inputs.version }}
         # ignore createdAt: if there's a new file it will always be newer
         if ${{ inputs.check_version }}; then
           # check version: version must match a known version (from Cargo.toml,
-          # or a present git tag)
+          # or a present git tag). For example on release runs.
           git diff \
             --ignore-matching-lines '^#' \
             --ignore-matching-lines '^createdAt'\
@@ -34,7 +39,7 @@ runs:
             (echo; echo "There are differences in artifacthub-pkg.yml that have to be checked in.\nIf version is outdated, run \`make --always-make artifacthub-pkg.yml VERSION=<new tag>\`"; exit 1)
         else
           # don't check_version: version must match a future tag that hasn't been
-          # created yet, so let's not check for it
+          # created yet, so let's not check for it. For example on CI runs.
           git diff \
             --ignore-matching-lines '^#' \
             --ignore-matching-lines '^createdAt'\

--- a/check-artifacthub/action.yml
+++ b/check-artifacthub/action.yml
@@ -1,25 +1,24 @@
-name: 'kubewarden-check-artifacthub'
-description: 'Check that artifacthub-pkg.yml is up-to-date'
+name: "kubewarden-check-artifacthub"
+description: "Check that artifacthub-pkg.yml is up-to-date"
 branding:
-  icon: 'package'
-  color: 'blue'
+  icon: "package"
+  color: "blue"
 inputs:
   version:
-    description: 'version string to use in artifacthub-plg.yml'
+    description: "version string to use in artifacthub-plg.yml"
     required: true
     type: string
   check_version:
-    description: 'check version string in comparison'
+    description: "check version string in comparison"
     default: true
     type: bool
 runs:
   using: "composite"
   steps:
-    -
-      name: Checkout code
+    - name: Checkout code
       uses: actions/checkout@v4
-    -
-      name: Check that artifacthub-pkg.yml is up-to-date
+
+    - name: Check that artifacthub-pkg.yml is up-to-date
       shell: bash
       run: |
         rm artifacthub-pkg.yml # force recreation of file

--- a/check-artifacthub/action.yml
+++ b/check-artifacthub/action.yml
@@ -26,7 +26,7 @@ runs:
       shell: bash
       working-directory: ${{ inputs.policy-working-dir }}
       run: |
-        rm artifacthub-pkg.yml # force recreation of file
+        rm -rf artifacthub-pkg.yml # force recreation of file
         make artifacthub-pkg.yml VERSION=${{ inputs.version }}
         # ignore createdAt: if there's a new file it will always be newer
         if ${{ inputs.check_version }}; then

--- a/check-artifacthub/action.yml
+++ b/check-artifacthub/action.yml
@@ -5,7 +5,7 @@ branding:
   color: "blue"
 inputs:
   version:
-    description: "version string to use when constructing artifacthub-pkg.yml"
+    description: "version string to use when constructing artifacthub-pkg.yml. E.g: 0.1.0"
     required: true
     type: string
   check_version:

--- a/opa-installer/action.yml
+++ b/opa-installer/action.yml
@@ -7,7 +7,7 @@ inputs:
   opa-version:
     description: "opa release to be installed"
     required: false
-    default: v0.32.0
+    default: v0.65.0
 runs:
   using: "composite"
   steps:

--- a/opa-installer/action.yml
+++ b/opa-installer/action.yml
@@ -1,11 +1,11 @@
-name: 'opa-installer'
-description: 'Install opa and add it to PATH'
+name: "opa-installer"
+description: "Install opa and add it to PATH"
 branding:
-  icon: 'package'
-  color: 'blue'
+  icon: "package"
+  color: "blue"
 inputs:
   opa-version:
-    description: 'opa release to be installed'
+    description: "opa release to be installed"
     required: false
     default: v0.32.0
 runs:

--- a/policy-release/action.yml
+++ b/policy-release/action.yml
@@ -1,11 +1,11 @@
-name: 'kubewarden-policy-release'
-description: 'Release a Kubewarden policy'
+name: "kubewarden-policy-release"
+description: "Release a Kubewarden policy"
 branding:
-  icon: 'package'
-  color: 'blue'
+  icon: "package"
+  color: "blue"
 inputs:
   annotated-wasm:
-    description: 'name of the annotated wasm file'
+    description: "name of the annotated wasm file"
     required: false
     default: annotated-policy.wasm
   oci-target:
@@ -17,15 +17,13 @@ inputs:
 runs:
   using: "composite"
   steps:
-    -
-      name: Login to GitHub Container Registry
+    - name: Login to GitHub Container Registry
       uses: docker/login-action@v3
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
         password: ${{ inputs.GITHUB_TOKEN }}
-    -
-      name: Publish Wasm policy artifact to OCI registry with the 'latest' tag
+    - name: Publish Wasm policy artifact to OCI registry with the 'latest' tag
       shell: bash
       if: ${{ startsWith(github.ref, 'refs/heads/') }}
       env:
@@ -37,8 +35,7 @@ runs:
 
         echo Keyless signing of policy using cosign
         cosign sign --yes ${IMMUTABLE_REF}
-    -
-      name: Publish Wasm policy artifact to OCI registry with the version tag and 'latest'
+    - name: Publish Wasm policy artifact to OCI registry with the version tag and 'latest'
       shell: bash
       if: ${{ startsWith(github.ref, 'refs/tags/') }}
       env:
@@ -52,8 +49,7 @@ runs:
 
         echo Keyless signing of policy using cosign
         cosign sign --yes ${IMMUTABLE_REF}
-    -
-      name: Create release
+    - name: Create release
       if: ${{ startsWith(github.ref, 'refs/tags/') }}
       uses: softprops/action-gh-release@v2
       env:

--- a/policy-release/action.yml
+++ b/policy-release/action.yml
@@ -80,8 +80,8 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
       with:
-        name: Release ${{ github.ref_name }}
         tag_name: ${{ github.ref }}
+        name: ${{ github.ref_name }}
         draft: false
         prerelease: ${{ steps.calculate-version.outputs.is_prerelease }}
         files: |

--- a/policy-release/action.yml
+++ b/policy-release/action.yml
@@ -20,27 +20,13 @@ inputs:
     type: string
     default: .
   policy-version:
-    description: "release version of the policy. Useful for repos with policies in folders"
-    required: false
+    description: "release version of the policy without `v` prefix. E.g: 0.1.0"
+    required: true
     type: string
 
 runs:
   using: "composite"
   steps:
-    - id: calculate-version
-      shell: bash
-      run: |
-        set -ex
-        if [ "${{ inputs.policy-version }}" != "" ];then 
-          # If present, it means we are dealing with tags in the form of PolicyName/v0.1.0
-          # Transform the passed policy-version=0.1.0 into version=v0.1.0
-          echo "version=v${{ inputs.policy-version }}" >> $GITHUB_OUTPUT
-          echo "is_prerelease=${{ contains(inputs.policy-version, '-alpha') || contains(inputs.policy-version, '-beta') || contains(inputs.policy-version, '-rc') }}" >> $GITHUB_OUTPUT
-        else
-          # We are dealing with normal tags. Use the full tag.
-          echo "version=$(echo $GITHUB_REF | sed -e 's|refs/tags/||')" >> $GITHUB_OUTPUT
-          echo "is_prerelease=${{ contains(github.ref, '-alpha') || contains(github.ref, '-beta') || contains(github.ref, '-rc') }}" >> $GITHUB_OUTPUT
-        fi
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v3
       with:
@@ -67,7 +53,7 @@ runs:
       working-directory: ${{ inputs.policy-working-dir }}
       run: |
         set -ex
-        export OCI_TAG=${{ steps.calculate-version.outputs.version }}
+        export OCI_TAG="v${{ inputs.policy-version }}"
 
         echo Pushing tagged policy to OCI container registry
         IMMUTABLE_REF=$(kwctl push -o json ${{ inputs.annotated-wasm }} ${{ inputs.oci-target }}:${OCI_TAG} | jq -r .immutable_ref)
@@ -83,7 +69,7 @@ runs:
         tag_name: ${{ github.ref }}
         name: ${{ github.ref_name }}
         draft: false
-        prerelease: ${{ steps.calculate-version.outputs.is_prerelease }}
+        prerelease: ${{ contains(inputs.policy-version, '-alpha') || contains(inputs.policy-version, '-beta') || contains(inputs.policy-version, '-rc') }}
         files: |
           ${{ inputs.policy-working-dir }}/policy.wasm
           ${{ inputs.policy-working-dir }}/policy-sbom.spdx.json

--- a/policy-release/action.yml
+++ b/policy-release/action.yml
@@ -14,9 +14,33 @@ inputs:
   GITHUB_TOKEN:
     required: true
     type: string
+  policy-working-dir:
+    description: "working directory of the policy. Useful for repos with policies in folders"
+    required: false
+    type: string
+    default: .
+  policy-version:
+    description: "release version of the policy. Useful for repos with policies in folders"
+    required: false
+    type: string
+
 runs:
   using: "composite"
   steps:
+    - id: calculate-version
+      shell: bash
+      run: |
+        set -ex
+        if [ "${{ inputs.policy-version }}" != "" ];then 
+          # If present, it means we are dealing with tags in the form of PolicyName/v0.1.0
+          # Transform the passed policy-version=0.1.0 into version=v0.1.0
+          echo "version=v${{ inputs.policy-version }}" >> $GITHUB_OUTPUT
+          echo "is_prerelease=${{ contains(inputs.policy-version, '-alpha') || contains(inputs.policy-version, '-beta') || contains(inputs.policy-version, '-rc') }}" >> $GITHUB_OUTPUT
+        else
+          # We are dealing with normal tags. Use the full tag.
+          echo "version=$(echo $GITHUB_REF | sed -e 's|refs/tags/||')" >> $GITHUB_OUTPUT
+          echo "is_prerelease=${{ contains(github.ref, '-alpha') || contains(github.ref, '-beta') || contains(github.ref, '-rc') }}" >> $GITHUB_OUTPUT
+        fi
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v3
       with:
@@ -30,37 +54,38 @@ runs:
         COSIGN_EXPERIMENTAL: 1
       run: |
         set -ex
-        echo Pushing policy to OCI container registry
+        echo Pushing :latest policy to OCI container registry
         IMMUTABLE_REF=$(kwctl push -o json ${{ inputs.annotated-wasm }} ${{ inputs.oci-target }}:latest | jq -r .immutable_ref)
 
         echo Keyless signing of policy using cosign
         cosign sign --yes ${IMMUTABLE_REF}
     - name: Publish Wasm policy artifact to OCI registry with the version tag and 'latest'
       shell: bash
-      if: ${{ startsWith(github.ref, 'refs/tags/') }}
+      if: ${{ ! startsWith(github.ref, 'refs/heads/') }}
       env:
         COSIGN_EXPERIMENTAL: 1
+      working-directory: ${{ inputs.policy-working-dir }}
       run: |
         set -ex
-        export OCI_TAG=$(echo $GITHUB_REF | sed -e "s|refs/tags/||")
+        export OCI_TAG=${{ steps.calculate-version.outputs.version }}
 
-        echo Pushing policy to OCI container registry
+        echo Pushing tagged policy to OCI container registry
         IMMUTABLE_REF=$(kwctl push -o json ${{ inputs.annotated-wasm }} ${{ inputs.oci-target }}:${OCI_TAG} | jq -r .immutable_ref)
 
         echo Keyless signing of policy using cosign
         cosign sign --yes ${IMMUTABLE_REF}
     - name: Create release
-      if: ${{ startsWith(github.ref, 'refs/tags/') }}
+      if: ${{ ! startsWith(github.ref, 'refs/heads/') }}
       uses: softprops/action-gh-release@v2
       env:
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
       with:
-        tag_name: ${{ github.ref }}
         name: Release ${{ github.ref_name }}
+        tag_name: ${{ github.ref }}
         draft: false
-        prerelease: ${{ contains(github.ref, '-alpha') || contains(github.ref, '-beta') || contains(github.ref, '-rc') }}
+        prerelease: ${{ steps.calculate-version.outputs.is_prerelease }}
         files: |
-          policy.wasm
-          policy-sbom.spdx.json
-          policy-sbom.spdx.cert
-          policy-sbom.spdx.sig
+          ${{ inputs.policy-working-dir }}/policy.wasm
+          ${{ inputs.policy-working-dir }}/policy-sbom.spdx.json
+          ${{ inputs.policy-working-dir }}/policy-sbom.spdx.cert
+          ${{ inputs.policy-working-dir }}/policy-sbom.spdx.sig

--- a/push-artifacthub/action.yml
+++ b/push-artifacthub/action.yml
@@ -3,12 +3,18 @@ description: "Push artifacthub files to artifacthub branch"
 branding:
   icon: "package"
   color: "blue"
+inputs:
+  policy-working-dir:
+    description: "working directory of the policy. Useful for repos with policies in folders"
+    required: false
+    type: string
+    default: .
 runs:
   using: "composite"
   steps:
     - name: Checkout code
       uses: actions/checkout@v4
-    - name: Check that artifacthub-pkg.yml is up-to-date
+    - name: Push up-to-date artifacthub-pkg.yml
       shell: bash
       run: |
         git config user.name "Update artifacthub branch"
@@ -16,9 +22,30 @@ runs:
 
         git checkout artifacthub || git checkout --orphan artifacthub
         git reset HEAD -- .
-        git add artifacthub-pkg.yml
-        git add artifacthub-repo.yml
-        git add README.md # used if artifacthub-pkg.yml.readme is missing
-        VERSION=$(sed --posix -n 's,^version: \(.*\),\1,p' artifacthub-pkg.yml)
-        git commit -m "Update Artifact Hub files, version $VERSION"
+
+        if [ ${{ inputs.policy-working-dir }} != '.' ]; then
+          # we need to replicate the policy-working-dir structure,
+          # see https://artifacthub.io/docs/topics/repositories/kubewarden-policies
+          #   path/to/packages
+          #   ├── artifacthub-repo.yml
+          #   └── policies/<policy name>
+          #       ├── README.md
+          #       └── artifacthub-pkg.yml
+          git add artifacthub-repo.yml
+          git add ${{ inputs.policy-working-dir }}/artifacthub-pkg.yml
+          git add ${{ inputs.policy-working-dir }}/README.md # used if artifacthub-pkg.yml.readme is missing
+          VERSION=$(sed --posix -n 's,^version: \(.*\),\1,p' ${{ inputs.policy-working-dir}}/artifacthub-pkg.yml)
+          git commit -m "Update Artifact Hub files, version $VERSION"
+        else 
+          # we put everything flat:
+          #   path/to/packages
+          #   ├── artifacthub-repo.yml
+          #   └── artifacthub-pkg.yml
+          git add artifacthub-pkg.yml
+          git add artifacthub-repo.yml
+          git add README.md # used if artifacthub-pkg.yml.readme is missing
+          VERSION=$(sed --posix -n 's,^version: \(.*\),\1,p' artifacthub-pkg.yml)
+          git commit -m "Update Artifact Hub files, version $VERSION"
+        fi
+
         git push --force origin artifacthub

--- a/push-artifacthub/action.yml
+++ b/push-artifacthub/action.yml
@@ -1,16 +1,14 @@
-name: 'kubewarden-check-artifacthub'
-description: 'Push artifacthub files to artifacthub branch'
+name: "kubewarden-check-artifacthub"
+description: "Push artifacthub files to artifacthub branch"
 branding:
-  icon: 'package'
-  color: 'blue'
+  icon: "package"
+  color: "blue"
 runs:
   using: "composite"
   steps:
-    -
-      name: Checkout code
+    - name: Checkout code
       uses: actions/checkout@v4
-    -
-      name: Check that artifacthub-pkg.yml is up-to-date
+    - name: Check that artifacthub-pkg.yml is up-to-date
       shell: bash
       run: |
         git config user.name "Update artifacthub branch"


### PR DESCRIPTION
## Description

Part of https://github.com/kubewarden/kubewarden-controller/issues/938

Flatten GH workflows into `.github/workflowsrelease.yml` for `slsactl` to work.

Now there's a bit of repetition between `release.yml` (from tags, builds, signs, attestates and pushes all that) and container-build (from main and feat branches, builds and pushes). But it eez what it eez.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
latest image:
https://github.com/viccuad/kubewarden-controller/actions/runs/12314469632/job/34370654865

tagged release:
https://github.com/viccuad/policy-server/actions/runs/12316544556
<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
