### PR TITLE
chore(deps): update version of tinygo

### DIFF
--- a/policy-build-tinygo/action.yml
+++ b/policy-build-tinygo/action.yml
@@ -7,7 +7,7 @@ inputs:
   tinygo-version:
     required: true
     description: "Version of tinygo to use"
-    default: 0.33.0
+    default: 0.34.0
   generate-sbom:
     required: false
     description: "Generate and sign SBOM files"


### PR DESCRIPTION
Use latest stable release of tinygo: 0.34.0

@viccuad: maybe we could merge that before you tag the next version of this repo