### PR TITLE
fix: Support repos where there's no tag at all 

### DIFF
--- a/.github/workflows/reusable-release-policy-assemblyscript.yml
+++ b/.github/workflows/reusable-release-policy-assemblyscript.yml
@@ -19,7 +19,7 @@ jobs:
       NODE_VERSION: 14
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.4.1
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.4.2
       - uses: actions/checkout@v4
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -48,7 +48,7 @@ jobs:
       - name: Check that artifacthub-pkg.yml is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub
-        uses: kubewarden/github-actions/check-artifacthub@v3.4.1
+        uses: kubewarden/github-actions/check-artifacthub@v3.4.2
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       - name: Setup node
@@ -71,7 +71,7 @@ jobs:
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@v3.4.1
+        uses: kubewarden/github-actions/policy-release@v3.4.2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -87,4 +87,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v3.4.1
+        uses: kubewarden/github-actions/push-artifacthub@v3.4.2

--- a/.github/workflows/reusable-release-policy-assemblyscript.yml
+++ b/.github/workflows/reusable-release-policy-assemblyscript.yml
@@ -34,11 +34,15 @@ jobs:
           else
             # Triggered via branch, version is not checked in artifacthub.
             # Still, `make artifacthub-pkg.yml` needs a proper semver string.
-            # 
-            # Use most recent tag with the number of additional commits on top
-            # of the tagged object & last commit hash (eg. v0.1.11-3-g8a36322),
-            # without the `v` prefix.
-            version=$(git describe --tags | cut -c2-)
+            if [ $(git describe --tags) ]; then
+              # Tag exists, use most recent tag with the number of additional
+              # commits on top of the tagged object & last commit hash (eg.
+              # v0.1.11-3-g8a36322), without the `v` prefix.
+              version=$(git describe --tags | cut -c2-)
+            else
+              # Tag doesn't exist, provide bogus version
+              version="0.0.0-$(git describe --always)-unreleased"
+            fi 
           fi
           echo "version=$version" >> $GITHUB_OUTPUT
       - name: Check that artifacthub-pkg.yml is up-to-date

--- a/.github/workflows/reusable-release-policy-go-wasi.yml
+++ b/.github/workflows/reusable-release-policy-go-wasi.yml
@@ -32,11 +32,15 @@ jobs:
           else
             # Triggered via branch, version is not checked in artifacthub.
             # Still, `make artifacthub-pkg.yml` needs a proper semver string.
-            # 
-            # Use most recent tag with the number of additional commits on top
-            # of the tagged object & last commit hash (eg. v0.1.11-3-g8a36322),
-            # without the `v` prefix.
-            version=$(git describe --tags | cut -c2-)
+            if [ $(git describe --tags) ]; then
+              # Tag exists, use most recent tag with the number of additional
+              # commits on top of the tagged object & last commit hash (eg.
+              # v0.1.11-3-g8a36322), without the `v` prefix.
+              version=$(git describe --tags | cut -c2-)
+            else
+              # Tag doesn't exist, provide bogus version
+              version="0.0.0-$(git describe --always)-unreleased"
+            fi 
           fi
           echo "version=$version" >> $GITHUB_OUTPUT
       - name: Check that artifacthub-pkg.yml is up-to-date

--- a/.github/workflows/reusable-release-policy-go-wasi.yml
+++ b/.github/workflows/reusable-release-policy-go-wasi.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.4.1
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.4.2
       - uses: actions/checkout@v4
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -46,16 +46,16 @@ jobs:
       - name: Check that artifacthub-pkg.yml is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub
-        uses: kubewarden/github-actions/check-artifacthub@v3.4.1
+        uses: kubewarden/github-actions/check-artifacthub@v3.4.2
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       - name: Build and annotate policy
-        uses: kubewarden/github-actions/policy-build-go-wasi@v3.4.1
+        uses: kubewarden/github-actions/policy-build-go-wasi@v3.4.2
       - name: Run e2e tests
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@v3.4.1
+        uses: kubewarden/github-actions/policy-release@v3.4.2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -71,4 +71,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v3.4.1
+        uses: kubewarden/github-actions/push-artifacthub@v3.4.2

--- a/.github/workflows/reusable-release-policy-go.yml
+++ b/.github/workflows/reusable-release-policy-go.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.4.1
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.4.2
       - uses: actions/checkout@v4
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -46,16 +46,16 @@ jobs:
       - name: Check that artifacthub-pkg.yml is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub
-        uses: kubewarden/github-actions/check-artifacthub@v3.4.1
+        uses: kubewarden/github-actions/check-artifacthub@v3.4.2
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       - name: Build and annotate policy
-        uses: kubewarden/github-actions/policy-build-tinygo@v3.4.1
+        uses: kubewarden/github-actions/policy-build-tinygo@v3.4.2
       - name: Run e2e tests
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@v3.4.1
+        uses: kubewarden/github-actions/policy-release@v3.4.2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -71,4 +71,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v3.4.1
+        uses: kubewarden/github-actions/push-artifacthub@v3.4.2

--- a/.github/workflows/reusable-release-policy-go.yml
+++ b/.github/workflows/reusable-release-policy-go.yml
@@ -32,11 +32,15 @@ jobs:
           else
             # Triggered via branch, version is not checked in artifacthub.
             # Still, `make artifacthub-pkg.yml` needs a proper semver string.
-            # 
-            # Use most recent tag with the number of additional commits on top
-            # of the tagged object & last commit hash (eg. v0.1.11-3-g8a36322),
-            # without the `v` prefix.
-            version=$(git describe --tags | cut -c2-)
+            if [ $(git describe --tags) ]; then
+              # Tag exists, use most recent tag with the number of additional
+              # commits on top of the tagged object & last commit hash (eg.
+              # v0.1.11-3-g8a36322), without the `v` prefix.
+              version=$(git describe --tags | cut -c2-)
+            else
+              # Tag doesn't exist, provide bogus version
+              version="0.0.0-$(git describe --always)-unreleased"
+            fi 
           fi
           echo "version=$version" >> $GITHUB_OUTPUT
       - name: Check that artifacthub-pkg.yml is up-to-date

--- a/.github/workflows/reusable-release-policy-rego.yml
+++ b/.github/workflows/reusable-release-policy-rego.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.4.1
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.4.2
       - uses: actions/checkout@v4
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -64,12 +64,12 @@ jobs:
       - name: Check that artifacthub-pkg.yml is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: ${{ inputs.artifacthub && ( ! startsWith(github.ref, 'refs/heads/') ) }}
-        uses: kubewarden/github-actions/check-artifacthub@v3.4.1
+        uses: kubewarden/github-actions/check-artifacthub@v3.4.2
         with:
           version: ${{ steps.calculate-version.outputs.version }}
           policy-working-dir: ${{ inputs.policy-working-dir }}
       - name: Install opa
-        uses: kubewarden/github-actions/opa-installer@v3.4.1
+        uses: kubewarden/github-actions/opa-installer@v3.4.2
       - uses: actions/checkout@v4
       - name: Build policy
         working-directory: ${{ inputs.policy-working-dir }}
@@ -87,7 +87,7 @@ jobs:
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@v3.4.1
+        uses: kubewarden/github-actions/policy-release@v3.4.2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -104,6 +104,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v3.4.1
+        uses: kubewarden/github-actions/push-artifacthub@v3.4.2
         with:
           policy-working-dir: ${{ inputs.policy-working-dir }}

--- a/.github/workflows/reusable-release-policy-rego.yml
+++ b/.github/workflows/reusable-release-policy-rego.yml
@@ -49,11 +49,15 @@ jobs:
             else
               # Triggered via branch, version is not checked in artifacthub.
               # Still, `make artifacthub-pkg.yml` needs a proper semver string.
-              # 
-              # Use most recent tag with the number of additional commits on top
-              # of the tagged object & last commit hash (eg. v0.1.11-3-g8a36322),
-              # without the `v` prefix.
-              version=$(git describe --tags | cut -c2-)
+              if [ $(git describe --tags) ]; then
+                # Tag exists, use most recent tag with the number of additional
+                # commits on top of the tagged object & last commit hash (eg.
+                # v0.1.11-3-g8a36322), without the `v` prefix.
+                version=$(git describe --tags | cut -c2-)
+              else
+                # Tag doesn't exist, provide bogus version
+                version="0.0.0-$(git describe --always)-unreleased"
+              fi 
             fi
           fi
           echo "version=$version" >> $GITHUB_OUTPUT

--- a/.github/workflows/reusable-release-policy-rust.yml
+++ b/.github/workflows/reusable-release-policy-rust.yml
@@ -32,11 +32,15 @@ jobs:
           else
             # Triggered via branch, version is not checked in artifacthub.
             # Still, `make artifacthub-pkg.yml` needs a proper semver string.
-            # 
-            # Use most recent tag with the number of additional commits on top
-            # of the tagged object & last commit hash (eg. v0.1.11-3-g8a36322),
-            # without the `v` prefix.
-            version=$(git describe --tags | cut -c2-)
+            if [ $(git describe --tags) ]; then
+              # Tag exists, use most recent tag with the number of additional
+              # commits on top of the tagged object & last commit hash (eg.
+              # v0.1.11-3-g8a36322), without the `v` prefix.
+              version=$(git describe --tags | cut -c2-)
+            else
+              # Tag doesn't exist, provide bogus version
+              version="0.0.0-$(git describe --always)-unreleased"
+            fi 
           fi
           echo "version=$version" >> $GITHUB_OUTPUT
       - name: Check that artifacthub-pkg.yml is up-to-date

--- a/.github/workflows/reusable-release-policy-rust.yml
+++ b/.github/workflows/reusable-release-policy-rust.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.4.1
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.4.2
       - uses: actions/checkout@v4
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -46,16 +46,16 @@ jobs:
       - name: Check that artifacthub-pkg.yml is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub
-        uses: kubewarden/github-actions/check-artifacthub@v3.4.1
+        uses: kubewarden/github-actions/check-artifacthub@v3.4.2
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       - name: Build and annotate policy
-        uses: kubewarden/github-actions/policy-build-rust@v3.4.1
+        uses: kubewarden/github-actions/policy-build-rust@v3.4.2
       - name: Run e2e tests
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@v3.4.1
+        uses: kubewarden/github-actions/policy-release@v3.4.2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -71,4 +71,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v3.4.1
+        uses: kubewarden/github-actions/push-artifacthub@v3.4.2

--- a/.github/workflows/reusable-release-policy-swift.yml
+++ b/.github/workflows/reusable-release-policy-swift.yml
@@ -32,11 +32,15 @@ jobs:
           else
             # Triggered via branch, version is not checked in artifacthub.
             # Still, `make artifacthub-pkg.yml` needs a proper semver string.
-            # 
-            # Use most recent tag with the number of additional commits on top
-            # of the tagged object & last commit hash (eg. v0.1.11-3-g8a36322),
-            # without the `v` prefix.
-            version=$(git describe --tags | cut -c2-)
+            if [ $(git describe --tags) ]; then
+              # Tag exists, use most recent tag with the number of additional
+              # commits on top of the tagged object & last commit hash (eg.
+              # v0.1.11-3-g8a36322), without the `v` prefix.
+              version=$(git describe --tags | cut -c2-)
+            else
+              # Tag doesn't exist, provide bogus version
+              version="0.0.0-$(git describe --always)-unreleased"
+            fi 
           fi
           echo "version=$version" >> $GITHUB_OUTPUT
       - name: Check that artifacthub-pkg.yml is up-to-date

--- a/.github/workflows/reusable-release-policy-swift.yml
+++ b/.github/workflows/reusable-release-policy-swift.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.4.1
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.4.2
       - uses: actions/checkout@v4
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -46,7 +46,7 @@ jobs:
       - name: Check that artifacthub-pkg.yml is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub
-        uses: kubewarden/github-actions/check-artifacthub@v3.4.1
+        uses: kubewarden/github-actions/check-artifacthub@v3.4.2
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       - name: install wasm-strip
@@ -72,7 +72,7 @@ jobs:
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@v3.4.1
+        uses: kubewarden/github-actions/policy-release@v3.4.2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -88,4 +88,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v3.4.1
+        uses: kubewarden/github-actions/push-artifacthub@v3.4.2

--- a/.github/workflows/reusable-test-policy-assemblyscript.yml
+++ b/.github/workflows/reusable-test-policy-assemblyscript.yml
@@ -46,11 +46,15 @@ jobs:
           else
             # Triggered via branch, version is not checked in artifacthub.
             # Still, `make artifacthub-pkg.yml` needs a proper semver string.
-            # 
-            # Use most recent tag with the number of additional commits on top
-            # of the tagged object & last commit hash (eg. v0.1.11-3-g8a36322),
-            # without the `v` prefix.
-            version=$(git describe --tags | cut -c2-)
+            if [ $(git describe --tags) ]; then
+              # Tag exists, use most recent tag with the number of additional
+              # commits on top of the tagged object & last commit hash (eg.
+              # v0.1.11-3-g8a36322), without the `v` prefix.
+              version=$(git describe --tags | cut -c2-)
+            else
+              # Tag doesn't exist, provide bogus version
+              version="0.0.0-$(git describe --always)-unreleased"
+            fi 
           fi
           echo "version=$version" >> $GITHUB_OUTPUT
       - name: Check that artifacthub-pkg.yml is up-to-date

--- a/.github/workflows/reusable-test-policy-assemblyscript.yml
+++ b/.github/workflows/reusable-test-policy-assemblyscript.yml
@@ -35,7 +35,7 @@ jobs:
           # until https://github.com/actions/checkout/pull/579 is released
           fetch-depth: 0
       - name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v3.4.1
+        uses: kubewarden/github-actions/kwctl-installer@v3.4.2
       - id: calculate-version
         shell: bash
         run: |
@@ -58,7 +58,7 @@ jobs:
           fi
           echo "version=$version" >> $GITHUB_OUTPUT
       - name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthub@v3.4.1
+        uses: kubewarden/github-actions/check-artifacthub@v3.4.2
         with:
           version: ${{ steps.calculate-version.outputs.version }}
           check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then

--- a/.github/workflows/reusable-test-policy-go-wasi.yml
+++ b/.github/workflows/reusable-test-policy-go-wasi.yml
@@ -29,11 +29,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.4.1
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.4.2
       - name: Build and annotate policy
         with:
           generate-sbom: false
-        uses: kubewarden/github-actions/policy-build-go-wasi@v3.4.1
+        uses: kubewarden/github-actions/policy-build-go-wasi@v3.4.2
       - name: Run e2e tests
         run: make e2e-tests
 
@@ -58,7 +58,7 @@ jobs:
           # until https://github.com/actions/checkout/pull/579 is released
           fetch-depth: 0
       - name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v3.4.1
+        uses: kubewarden/github-actions/kwctl-installer@v3.4.2
       - id: calculate-version
         shell: bash
         run: |
@@ -81,7 +81,7 @@ jobs:
           fi
           echo "version=$version" >> $GITHUB_OUTPUT
       - name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthub@v3.4.1
+        uses: kubewarden/github-actions/check-artifacthub@v3.4.2
         with:
           version: ${{ steps.calculate-version.outputs.version }}
           check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then

--- a/.github/workflows/reusable-test-policy-go-wasi.yml
+++ b/.github/workflows/reusable-test-policy-go-wasi.yml
@@ -69,11 +69,15 @@ jobs:
           else
             # Triggered via branch, version is not checked in artifacthub.
             # Still, `make artifacthub-pkg.yml` needs a proper semver string.
-            # 
-            # Use most recent tag with the number of additional commits on top
-            # of the tagged object & last commit hash (eg. v0.1.11-3-g8a36322),
-            # without the `v` prefix.
-            version=$(git describe --tags | cut -c2-)
+            if [ $(git describe --tags) ]; then
+              # Tag exists, use most recent tag with the number of additional
+              # commits on top of the tagged object & last commit hash (eg.
+              # v0.1.11-3-g8a36322), without the `v` prefix.
+              version=$(git describe --tags | cut -c2-)
+            else
+              # Tag doesn't exist, provide bogus version
+              version="0.0.0-$(git describe --always)-unreleased"
+            fi 
           fi
           echo "version=$version" >> $GITHUB_OUTPUT
       - name: Check that artifacthub-pkg.yml is up-to-date

--- a/.github/workflows/reusable-test-policy-go.yml
+++ b/.github/workflows/reusable-test-policy-go.yml
@@ -29,11 +29,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.4.1
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.4.2
       - name: Build and annotate policy
         with:
           generate-sbom: false
-        uses: kubewarden/github-actions/policy-build-tinygo@v3.4.1
+        uses: kubewarden/github-actions/policy-build-tinygo@v3.4.2
       - name: Run e2e tests
         run: make e2e-tests
 
@@ -58,7 +58,7 @@ jobs:
           # until https://github.com/actions/checkout/pull/579 is released
           fetch-depth: 0
       - name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v3.4.1
+        uses: kubewarden/github-actions/kwctl-installer@v3.4.2
       - id: calculate-version
         shell: bash
         run: |
@@ -81,7 +81,7 @@ jobs:
           fi
           echo "version=$version" >> $GITHUB_OUTPUT
       - name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthub@v3.4.1
+        uses: kubewarden/github-actions/check-artifacthub@v3.4.2
         with:
           version: ${{ steps.calculate-version.outputs.version }}
           check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then

--- a/.github/workflows/reusable-test-policy-go.yml
+++ b/.github/workflows/reusable-test-policy-go.yml
@@ -69,11 +69,15 @@ jobs:
           else
             # Triggered via branch, version is not checked in artifacthub.
             # Still, `make artifacthub-pkg.yml` needs a proper semver string.
-            # 
-            # Use most recent tag with the number of additional commits on top
-            # of the tagged object & last commit hash (eg. v0.1.11-3-g8a36322),
-            # without the `v` prefix.
-            version=$(git describe --tags | cut -c2-)
+            if [ $(git describe --tags) ]; then
+              # Tag exists, use most recent tag with the number of additional
+              # commits on top of the tagged object & last commit hash (eg.
+              # v0.1.11-3-g8a36322), without the `v` prefix.
+              version=$(git describe --tags | cut -c2-)
+            else
+              # Tag doesn't exist, provide bogus version
+              version="0.0.0-$(git describe --always)-unreleased"
+            fi 
           fi
           echo "version=$version" >> $GITHUB_OUTPUT
       - name: Check that artifacthub-pkg.yml is up-to-date

--- a/.github/workflows/reusable-test-policy-rego.yml
+++ b/.github/workflows/reusable-test-policy-rego.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install opa
-        uses: kubewarden/github-actions/opa-installer@v3.4.1
+        uses: kubewarden/github-actions/opa-installer@v3.4.2
       - name: Run unit tests
         working-directory: ${{ inputs.policy-working-dir }}
         run: make test
@@ -42,7 +42,7 @@ jobs:
           # until https://github.com/actions/checkout/pull/579 is released
           fetch-depth: 0
       - name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v3.4.1
+        uses: kubewarden/github-actions/kwctl-installer@v3.4.2
       - id: calculate-version
         shell: bash
         run: |
@@ -73,7 +73,7 @@ jobs:
       - name: Check that artifacthub-pkg.yml is up-to-date
         # only makes sense to run this check if artifacthub-pkg.yml has been
         # updated for an upcoming release.
-        uses: kubewarden/github-actions/check-artifacthub@v3.4.1
+        uses: kubewarden/github-actions/check-artifacthub@v3.4.2
         with:
           version: ${{ steps.calculate-version.outputs.version }}
           check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then

--- a/.github/workflows/reusable-test-policy-rego.yml
+++ b/.github/workflows/reusable-test-policy-rego.yml
@@ -58,11 +58,15 @@ jobs:
             else
               # Triggered via branch, version is not checked in artifacthub.
               # Still, `make artifacthub-pkg.yml` needs a proper semver string.
-              # 
-              # Use most recent tag with the number of additional commits on top
-              # of the tagged object & last commit hash (eg. v0.1.11-3-g8a36322),
-              # without the `v` prefix.
-              version=$(git describe --tags | cut -c2-)
+              if [ $(git describe --tags) ]; then
+                # Tag exists, use most recent tag with the number of additional
+                # commits on top of the tagged object & last commit hash (eg.
+                # v0.1.11-3-g8a36322), without the `v` prefix.
+                version=$(git describe --tags | cut -c2-)
+              else
+                # Tag doesn't exist, provide bogus version
+                version="0.0.0-$(git describe --always)-unreleased"
+              fi 
             fi
           fi
           echo "version=$version" >> $GITHUB_OUTPUT

--- a/.github/workflows/reusable-test-policy-rust.yml
+++ b/.github/workflows/reusable-test-policy-rust.yml
@@ -46,11 +46,15 @@ jobs:
           else
             # Triggered via branch, version is not checked in artifacthub.
             # Still, `make artifacthub-pkg.yml` needs a proper semver string.
-            # 
-            # Use most recent tag with the number of additional commits on top
-            # of the tagged object & last commit hash (eg. v0.1.11-3-g8a36322),
-            # without the `v` prefix.
-            version=$(git describe --tags | cut -c2-)
+            if [ $(git describe --tags) ]; then
+              # Tag exists, use most recent tag with the number of additional
+              # commits on top of the tagged object & last commit hash (eg.
+              # v0.1.11-3-g8a36322), without the `v` prefix.
+              version=$(git describe --tags | cut -c2-)
+            else
+              # Tag doesn't exist, provide bogus version
+              version="0.0.0-$(git describe --always)-unreleased"
+            fi 
           fi
           echo "version=$version" >> $GITHUB_OUTPUT
       - name: Check that artifacthub-pkg.yml is up-to-date

--- a/.github/workflows/reusable-test-policy-rust.yml
+++ b/.github/workflows/reusable-test-policy-rust.yml
@@ -35,7 +35,7 @@ jobs:
           # until https://github.com/actions/checkout/pull/579 is released
           fetch-depth: 0
       - name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v3.4.1
+        uses: kubewarden/github-actions/kwctl-installer@v3.4.2
       - id: calculate-version
         shell: bash
         run: |
@@ -58,7 +58,7 @@ jobs:
           fi
           echo "version=$version" >> $GITHUB_OUTPUT
       - name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthub@v3.4.1
+        uses: kubewarden/github-actions/check-artifacthub@v3.4.2
         with:
           version: ${{ steps.calculate-version.outputs.version }}
           check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then
@@ -94,11 +94,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.4.1
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.4.2
       - name: Build and annotate policy
         with:
           generate-sbom: false
-        uses: kubewarden/github-actions/policy-build-rust@v3.4.1
+        uses: kubewarden/github-actions/policy-build-rust@v3.4.2
       - name: Run e2e tests
         run: |
           make e2e-tests

--- a/.github/workflows/reusable-test-policy-swift.yml
+++ b/.github/workflows/reusable-test-policy-swift.yml
@@ -29,7 +29,7 @@ jobs:
           # until https://github.com/actions/checkout/pull/579 is released
           fetch-depth: 0
       - name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v3.4.1
+        uses: kubewarden/github-actions/kwctl-installer@v3.4.2
       - id: calculate-version
         shell: bash
         run: |
@@ -52,7 +52,7 @@ jobs:
           fi
           echo "version=$version" >> $GITHUB_OUTPUT
       - name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthub@v3.4.1
+        uses: kubewarden/github-actions/check-artifacthub@v3.4.2
         with:
           version: ${{ steps.calculate-version.outputs.version }}
           check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then

--- a/.github/workflows/reusable-test-policy-swift.yml
+++ b/.github/workflows/reusable-test-policy-swift.yml
@@ -40,11 +40,15 @@ jobs:
           else
             # Triggered via branch, version is not checked in artifacthub.
             # Still, `make artifacthub-pkg.yml` needs a proper semver string.
-            # 
-            # Use most recent tag with the number of additional commits on top
-            # of the tagged object & last commit hash (eg. v0.1.11-3-g8a36322),
-            # without the `v` prefix.
-            version=$(git describe --tags | cut -c2-)
+            if [ $(git describe --tags) ]; then
+              # Tag exists, use most recent tag with the number of additional
+              # commits on top of the tagged object & last commit hash (eg.
+              # v0.1.11-3-g8a36322), without the `v` prefix.
+              version=$(git describe --tags | cut -c2-)
+            else
+              # Tag doesn't exist, provide bogus version
+              version="0.0.0-$(git describe --always)-unreleased"
+            fi 
           fi
           echo "version=$version" >> $GITHUB_OUTPUT
       - name: Check that artifacthub-pkg.yml is up-to-date

--- a/policy-gh-action-dependencies/action.yml
+++ b/policy-gh-action-dependencies/action.yml
@@ -9,12 +9,12 @@ runs:
     - name: Install cosign
       uses: sigstore/cosign-installer@v3
     - name: Install kwctl
-      uses: kubewarden/github-actions/kwctl-installer@v3.4.1
+      uses: kubewarden/github-actions/kwctl-installer@v3.4.2
     - name: Install bats
       uses: mig4/setup-bats@v1.2.0
       with:
         bats-version: 1.11.0
     - name: Install SBOM generator tool
-      uses: kubewarden/github-actions/sbom-generator-installer@v3.4.1
+      uses: kubewarden/github-actions/sbom-generator-installer@v3.4.2
     - name: Install SBOM generator tool
-      uses: kubewarden/github-actions/binaryen-installer@v3.4.1
+      uses: kubewarden/github-actions/binaryen-installer@v3.4.2


### PR DESCRIPTION
## Description

This fixes `:latest` and CI for repos where the policy has never had a tag. E.g of failure without this fix:
https://github.com/kubewarden/raw-mutation-wasi-policy/actions/runs/12430796708/job/34706956927

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
tested locally.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

Once merged, needs to be tagged as `v3.4.2`.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
