### PR TITLE
fix: temporarily downgrade tinygo version

### DIFF
--- a/policy-build-tinygo/action.yml
+++ b/policy-build-tinygo/action.yml
@@ -7,7 +7,7 @@ inputs:
   tinygo-version:
     required: true
     description: "Version of tinygo to use"
-    default: 0.35.0
+    default: 0.34.0
   generate-sbom:
     required: false
     description: "Generate and sign SBOM files"


### PR DESCRIPTION
Starting from tinygo 0.35.0, our policies cannot run because of an issue inside of wapc's wasmtime-provider crate.

The issue has been fixed upstream and it will be part of the next release of Kubewarden (1.21.0).

In the meantime, we have to downgrade the version of tinygo used by our GHA, otherwise e2e tests will fail and it will be impossible to release fixes for the tinygo policies.
