### PR TITLE
update kwctl

### DIFF
--- a/.github/workflows/reusable-release-policy-assemblyscript.yml
+++ b/.github/workflows/reusable-release-policy-assemblyscript.yml
@@ -19,7 +19,7 @@ jobs:
       NODE_VERSION: 14
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.4.6
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.4.7
       - uses: actions/checkout@v4
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -48,7 +48,7 @@ jobs:
       - name: Check that artifacthub-pkg.yml is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub
-        uses: kubewarden/github-actions/check-artifacthub@v3.4.6
+        uses: kubewarden/github-actions/check-artifacthub@v3.4.7
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       - name: Setup node
@@ -71,7 +71,7 @@ jobs:
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@v3.4.6
+        uses: kubewarden/github-actions/policy-release@v3.4.7
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -87,4 +87,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v3.4.6
+        uses: kubewarden/github-actions/push-artifacthub@v3.4.7

--- a/.github/workflows/reusable-release-policy-go-wasi.yml
+++ b/.github/workflows/reusable-release-policy-go-wasi.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.4.6
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.4.7
       - uses: actions/checkout@v4
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -46,16 +46,16 @@ jobs:
       - name: Check that artifacthub-pkg.yml is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub
-        uses: kubewarden/github-actions/check-artifacthub@v3.4.6
+        uses: kubewarden/github-actions/check-artifacthub@v3.4.7
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       - name: Build and annotate policy
-        uses: kubewarden/github-actions/policy-build-go-wasi@v3.4.6
+        uses: kubewarden/github-actions/policy-build-go-wasi@v3.4.7
       - name: Run e2e tests
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@v3.4.6
+        uses: kubewarden/github-actions/policy-release@v3.4.7
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -71,4 +71,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v3.4.6
+        uses: kubewarden/github-actions/push-artifacthub@v3.4.7

--- a/.github/workflows/reusable-release-policy-go.yml
+++ b/.github/workflows/reusable-release-policy-go.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.4.6
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.4.7
       - uses: actions/checkout@v4
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -46,16 +46,16 @@ jobs:
       - name: Check that artifacthub-pkg.yml is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub
-        uses: kubewarden/github-actions/check-artifacthub@v3.4.6
+        uses: kubewarden/github-actions/check-artifacthub@v3.4.7
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       - name: Build and annotate policy
-        uses: kubewarden/github-actions/policy-build-tinygo@v3.4.6
+        uses: kubewarden/github-actions/policy-build-tinygo@v3.4.7
       - name: Run e2e tests
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@v3.4.6
+        uses: kubewarden/github-actions/policy-release@v3.4.7
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -71,4 +71,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v3.4.6
+        uses: kubewarden/github-actions/push-artifacthub@v3.4.7

--- a/.github/workflows/reusable-release-policy-rego.yml
+++ b/.github/workflows/reusable-release-policy-rego.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.4.6
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.4.7
       - uses: actions/checkout@v4
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -64,12 +64,12 @@ jobs:
       - name: Check that artifacthub-pkg.yml is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: ${{ inputs.artifacthub && ( ! startsWith(github.ref, 'refs/heads/') ) }}
-        uses: kubewarden/github-actions/check-artifacthub@v3.4.6
+        uses: kubewarden/github-actions/check-artifacthub@v3.4.7
         with:
           version: ${{ steps.calculate-version.outputs.version }}
           policy-working-dir: ${{ inputs.policy-working-dir }}
       - name: Install opa
-        uses: kubewarden/github-actions/opa-installer@v3.4.6
+        uses: kubewarden/github-actions/opa-installer@v3.4.7
       - uses: actions/checkout@v4
       - name: Build policy
         working-directory: ${{ inputs.policy-working-dir }}
@@ -87,7 +87,7 @@ jobs:
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@v3.4.6
+        uses: kubewarden/github-actions/policy-release@v3.4.7
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -104,6 +104,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v3.4.6
+        uses: kubewarden/github-actions/push-artifacthub@v3.4.7
         with:
           policy-working-dir: ${{ inputs.policy-working-dir }}

--- a/.github/workflows/reusable-release-policy-rust.yml
+++ b/.github/workflows/reusable-release-policy-rust.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.4.6
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.4.7
       - uses: actions/checkout@v4
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -46,16 +46,16 @@ jobs:
       - name: Check that artifacthub-pkg.yml is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub
-        uses: kubewarden/github-actions/check-artifacthub@v3.4.6
+        uses: kubewarden/github-actions/check-artifacthub@v3.4.7
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       - name: Build and annotate policy
-        uses: kubewarden/github-actions/policy-build-rust@v3.4.6
+        uses: kubewarden/github-actions/policy-build-rust@v3.4.7
       - name: Run e2e tests
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@v3.4.6
+        uses: kubewarden/github-actions/policy-release@v3.4.7
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -71,4 +71,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v3.4.6
+        uses: kubewarden/github-actions/push-artifacthub@v3.4.7

--- a/.github/workflows/reusable-release-policy-swift.yml
+++ b/.github/workflows/reusable-release-policy-swift.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.4.6
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.4.7
       - uses: actions/checkout@v4
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -46,7 +46,7 @@ jobs:
       - name: Check that artifacthub-pkg.yml is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v') && inputs.artifacthub
-        uses: kubewarden/github-actions/check-artifacthub@v3.4.6
+        uses: kubewarden/github-actions/check-artifacthub@v3.4.7
         with:
           version: ${{ steps.calculate-version.outputs.version }}
       - name: install wasm-strip
@@ -72,7 +72,7 @@ jobs:
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@v3.4.6
+        uses: kubewarden/github-actions/policy-release@v3.4.7
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -88,4 +88,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v3.4.6
+        uses: kubewarden/github-actions/push-artifacthub@v3.4.7

--- a/.github/workflows/reusable-test-policy-assemblyscript.yml
+++ b/.github/workflows/reusable-test-policy-assemblyscript.yml
@@ -35,7 +35,7 @@ jobs:
           # until https://github.com/actions/checkout/pull/579 is released
           fetch-depth: 0
       - name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v3.4.6
+        uses: kubewarden/github-actions/kwctl-installer@v3.4.7
       - id: calculate-version
         shell: bash
         run: |
@@ -58,7 +58,7 @@ jobs:
           fi
           echo "version=$version" >> $GITHUB_OUTPUT
       - name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthub@v3.4.6
+        uses: kubewarden/github-actions/check-artifacthub@v3.4.7
         with:
           version: ${{ steps.calculate-version.outputs.version }}
           check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then

--- a/.github/workflows/reusable-test-policy-go-wasi.yml
+++ b/.github/workflows/reusable-test-policy-go-wasi.yml
@@ -29,11 +29,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.4.6
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.4.7
       - name: Build and annotate policy
         with:
           generate-sbom: false
-        uses: kubewarden/github-actions/policy-build-go-wasi@v3.4.6
+        uses: kubewarden/github-actions/policy-build-go-wasi@v3.4.7
       - name: Run e2e tests
         run: make e2e-tests
 
@@ -58,7 +58,7 @@ jobs:
           # until https://github.com/actions/checkout/pull/579 is released
           fetch-depth: 0
       - name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v3.4.6
+        uses: kubewarden/github-actions/kwctl-installer@v3.4.7
       - id: calculate-version
         shell: bash
         run: |
@@ -81,7 +81,7 @@ jobs:
           fi
           echo "version=$version" >> $GITHUB_OUTPUT
       - name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthub@v3.4.6
+        uses: kubewarden/github-actions/check-artifacthub@v3.4.7
         with:
           version: ${{ steps.calculate-version.outputs.version }}
           check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then

--- a/.github/workflows/reusable-test-policy-go.yml
+++ b/.github/workflows/reusable-test-policy-go.yml
@@ -29,11 +29,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.4.6
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.4.7
       - name: Build and annotate policy
         with:
           generate-sbom: false
-        uses: kubewarden/github-actions/policy-build-tinygo@v3.4.6
+        uses: kubewarden/github-actions/policy-build-tinygo@v3.4.7
       - name: Run e2e tests
         run: make e2e-tests
 
@@ -58,7 +58,7 @@ jobs:
           # until https://github.com/actions/checkout/pull/579 is released
           fetch-depth: 0
       - name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v3.4.6
+        uses: kubewarden/github-actions/kwctl-installer@v3.4.7
       - id: calculate-version
         shell: bash
         run: |
@@ -81,7 +81,7 @@ jobs:
           fi
           echo "version=$version" >> $GITHUB_OUTPUT
       - name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthub@v3.4.6
+        uses: kubewarden/github-actions/check-artifacthub@v3.4.7
         with:
           version: ${{ steps.calculate-version.outputs.version }}
           check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then

--- a/.github/workflows/reusable-test-policy-rego.yml
+++ b/.github/workflows/reusable-test-policy-rego.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install opa
-        uses: kubewarden/github-actions/opa-installer@v3.4.6
+        uses: kubewarden/github-actions/opa-installer@v3.4.7
       - name: Run unit tests
         working-directory: ${{ inputs.policy-working-dir }}
         run: make test
@@ -42,7 +42,7 @@ jobs:
           # until https://github.com/actions/checkout/pull/579 is released
           fetch-depth: 0
       - name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v3.4.6
+        uses: kubewarden/github-actions/kwctl-installer@v3.4.7
       - id: calculate-version
         shell: bash
         run: |
@@ -73,7 +73,7 @@ jobs:
       - name: Check that artifacthub-pkg.yml is up-to-date
         # only makes sense to run this check if artifacthub-pkg.yml has been
         # updated for an upcoming release.
-        uses: kubewarden/github-actions/check-artifacthub@v3.4.6
+        uses: kubewarden/github-actions/check-artifacthub@v3.4.7
         with:
           version: ${{ steps.calculate-version.outputs.version }}
           check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then

--- a/.github/workflows/reusable-test-policy-rust.yml
+++ b/.github/workflows/reusable-test-policy-rust.yml
@@ -35,7 +35,7 @@ jobs:
           # until https://github.com/actions/checkout/pull/579 is released
           fetch-depth: 0
       - name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v3.4.6
+        uses: kubewarden/github-actions/kwctl-installer@v3.4.7
       - id: calculate-version
         shell: bash
         run: |
@@ -58,7 +58,7 @@ jobs:
           fi
           echo "version=$version" >> $GITHUB_OUTPUT
       - name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthub@v3.4.6
+        uses: kubewarden/github-actions/check-artifacthub@v3.4.7
         with:
           version: ${{ steps.calculate-version.outputs.version }}
           check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then
@@ -94,11 +94,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.4.6
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v3.4.7
       - name: Build and annotate policy
         with:
           generate-sbom: false
-        uses: kubewarden/github-actions/policy-build-rust@v3.4.6
+        uses: kubewarden/github-actions/policy-build-rust@v3.4.7
       - name: Run e2e tests
         run: |
           make e2e-tests

--- a/.github/workflows/reusable-test-policy-swift.yml
+++ b/.github/workflows/reusable-test-policy-swift.yml
@@ -29,7 +29,7 @@ jobs:
           # until https://github.com/actions/checkout/pull/579 is released
           fetch-depth: 0
       - name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v3.4.6
+        uses: kubewarden/github-actions/kwctl-installer@v3.4.7
       - id: calculate-version
         shell: bash
         run: |
@@ -52,7 +52,7 @@ jobs:
           fi
           echo "version=$version" >> $GITHUB_OUTPUT
       - name: Check that artifacthub-pkg.yml is up-to-date
-        uses: kubewarden/github-actions/check-artifacthub@v3.4.6
+        uses: kubewarden/github-actions/check-artifacthub@v3.4.7
         with:
           version: ${{ steps.calculate-version.outputs.version }}
           check_version: false # must match a git tag that hasn't been created yet, so let's ignore until then

--- a/kwctl-installer/action.yml
+++ b/kwctl-installer/action.yml
@@ -7,7 +7,7 @@ inputs:
   KWCTL_VERSION:
     description: "kwctl release to be installed"
     required: false
-    default: v1.21.1
+    default: v1.22.0
 runs:
   using: "composite"
   steps:

--- a/policy-gh-action-dependencies/action.yml
+++ b/policy-gh-action-dependencies/action.yml
@@ -9,12 +9,12 @@ runs:
     - name: Install cosign
       uses: sigstore/cosign-installer@v3
     - name: Install kwctl
-      uses: kubewarden/github-actions/kwctl-installer@v3.4.6
+      uses: kubewarden/github-actions/kwctl-installer@v3.4.7
     - name: Install bats
       uses: mig4/setup-bats@v1.2.0
       with:
         bats-version: 1.11.0
     - name: Install SBOM generator tool
-      uses: kubewarden/github-actions/sbom-generator-installer@v3.4.6
+      uses: kubewarden/github-actions/sbom-generator-installer@v3.4.7
     - name: Install SBOM generator tool
-      uses: kubewarden/github-actions/binaryen-installer@v3.4.6
+      uses: kubewarden/github-actions/binaryen-installer@v3.4.7


### PR DESCRIPTION
Update to latest kwctl. The 1.22 release of kwctl consumes the upstream crate of Sigstore and, most important of all, pushes additional annotations to our OCI artifacts.

Once merged, I'll tag a new release of this repo
