### PR TITLE
ci: pin GHA by checksum

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,9 @@
   "extends": [
     "config:base",
     "group:allNonMajor",
-    "schedule:earlyMondays"
+    "helpers:pinGitHubActionDigests",
+    "schedule:earlyMondays",
   ],
-  "labels": ["area/dependencies"]
+  "labels": ["area/dependencies"],
+  "ignoreDeps": ["kubewarden/github-actions"]
 }


### PR DESCRIPTION
On the next run, renovatebot will update all our GHA actions to be pinned with checksum.
