### PR TITLE
feat: add policy catalog repository dispatch

### DIFF
--- a/.github/workflows/reusable-release-policy-assemblyscript.yml
+++ b/.github/workflows/reusable-release-policy-assemblyscript.yml
@@ -27,7 +27,7 @@ jobs:
       NODE_VERSION: 14
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.0.0
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.1.0
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -56,7 +56,7 @@ jobs:
       - name: Check that `io.kubewarden.policy.version` annotation is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: kubewarden/github-actions/check-policy-version@v4.0.0
+        uses: kubewarden/github-actions/check-policy-version@v4.1.0
         with:
           expected-version: ${{ steps.calculate-version.outputs.version }}
       - name: Setup node
@@ -79,7 +79,7 @@ jobs:
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@v4.0.0
+        uses: kubewarden/github-actions/policy-release@v4.1.0
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -95,7 +95,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v4.0.0
+        uses: kubewarden/github-actions/push-artifacthub@v4.1.0
   release-catalog:
     # skip when releasing :latest from main, versions will not match
     if: ${{ inputs.artifacthub && ( ! startsWith(github.ref, 'refs/heads/') ) }} && inputs.release-catalog
@@ -103,6 +103,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Update the Kubewarden policy catalog after a release"
-        uses: kubewarden/github-actions/policy-release-catalog@v4.0.0
+        uses: kubewarden/github-actions/policy-release-catalog@v4.1.0
         with:
           WORKFLOW_PAT: ${{ secrets.WORKFLOW_PAT }}

--- a/.github/workflows/reusable-release-policy-assemblyscript.yml
+++ b/.github/workflows/reusable-release-policy-assemblyscript.yml
@@ -11,6 +11,14 @@ on:
         required: false
         type: boolean
         default: true
+      release-catalog:
+        description: "Update the Kubewarden policy catalog after a release"
+        type: boolean
+        default: false
+    secrets:
+      WORKFLOW_PAT:
+        description: "Personal access token used to trigger the policy-catalog workflow"
+        required: false
 
 jobs:
   release:
@@ -88,3 +96,13 @@ jobs:
     steps:
       - name: Push artifacthub files to artifacthub branch
         uses: kubewarden/github-actions/push-artifacthub@v4.0.0
+  release-catalog:
+    # skip when releasing :latest from main, versions will not match
+    if: ${{ inputs.artifacthub && ( ! startsWith(github.ref, 'refs/heads/') ) }} && inputs.release-catalog
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Update the Kubewarden policy catalog after a release"
+        uses: kubewarden/github-actions/policy-release-catalog@v4.0.0
+        with:
+          WORKFLOW_PAT: ${{ secrets.WORKFLOW_PAT }}

--- a/.github/workflows/reusable-release-policy-go-wasi.yml
+++ b/.github/workflows/reusable-release-policy-go-wasi.yml
@@ -11,6 +11,14 @@ on:
         required: false
         type: boolean
         default: true
+      release-catalog:
+        description: "Update the Kubewarden policy catalog after a release"
+        type: boolean
+        default: false
+    secrets:
+      WORKFLOW_PAT:
+        description: "Personal access token used to trigger the policy-catalog workflow"
+        required: false
 
 jobs:
   release:
@@ -72,3 +80,13 @@ jobs:
     steps:
       - name: Push artifacthub files to artifacthub branch
         uses: kubewarden/github-actions/push-artifacthub@v4.0.0
+  release-catalog:
+    # skip when releasing :latest from main, versions will not match
+    if: ${{ inputs.artifacthub && ( ! startsWith(github.ref, 'refs/heads/') ) }} && inputs.release-catalog
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Update the Kubewarden policy catalog after a release"
+        uses: kubewarden/github-actions/policy-release-catalog@v4.0.0
+        with:
+          WORKFLOW_PAT: ${{ secrets.WORKFLOW_PAT }}

--- a/.github/workflows/reusable-release-policy-go-wasi.yml
+++ b/.github/workflows/reusable-release-policy-go-wasi.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.0.0
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.1.0
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -54,16 +54,16 @@ jobs:
       - name: Check that `io.kubewarden.policy.version` annotation is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: kubewarden/github-actions/check-policy-version@v4.0.0
+        uses: kubewarden/github-actions/check-policy-version@v4.1.0
         with:
           expected-version: ${{ steps.calculate-version.outputs.version }}
       - name: Build and annotate policy
-        uses: kubewarden/github-actions/policy-build-go-wasi@v4.0.0
+        uses: kubewarden/github-actions/policy-build-go-wasi@v4.1.0
       - name: Run e2e tests
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@v4.0.0
+        uses: kubewarden/github-actions/policy-release@v4.1.0
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v4.0.0
+        uses: kubewarden/github-actions/push-artifacthub@v4.1.0
   release-catalog:
     # skip when releasing :latest from main, versions will not match
     if: ${{ inputs.artifacthub && ( ! startsWith(github.ref, 'refs/heads/') ) }} && inputs.release-catalog
@@ -87,6 +87,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Update the Kubewarden policy catalog after a release"
-        uses: kubewarden/github-actions/policy-release-catalog@v4.0.0
+        uses: kubewarden/github-actions/policy-release-catalog@v4.1.0
         with:
           WORKFLOW_PAT: ${{ secrets.WORKFLOW_PAT }}

--- a/.github/workflows/reusable-release-policy-go.yml
+++ b/.github/workflows/reusable-release-policy-go.yml
@@ -11,6 +11,14 @@ on:
         required: false
         type: boolean
         default: true
+      release-catalog:
+        description: "Update the Kubewarden policy catalog after a release"
+        type: boolean
+        default: false
+    secrets:
+      WORKFLOW_PAT:
+        description: "Personal access token used to trigger the policy-catalog workflow"
+        required: false
 
 jobs:
   release:
@@ -72,3 +80,13 @@ jobs:
     steps:
       - name: Push artifacthub files to artifacthub branch
         uses: kubewarden/github-actions/push-artifacthub@v4.0.0
+  release-catalog:
+    # skip when releasing :latest from main, versions will not match
+    if: ${{ inputs.artifacthub && ( ! startsWith(github.ref, 'refs/heads/') ) }} && inputs.release-catalog
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Update the Kubewarden policy catalog after a release"
+        uses: kubewarden/github-actions/policy-release-catalog@v4.0.0
+        with:
+          WORKFLOW_PAT: ${{ secrets.WORKFLOW_PAT }}

--- a/.github/workflows/reusable-release-policy-go.yml
+++ b/.github/workflows/reusable-release-policy-go.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.0.0
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.1.0
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -54,16 +54,16 @@ jobs:
       - name: Check that `io.kubewarden.policy.version` annotation is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: kubewarden/github-actions/check-policy-version@v4.0.0
+        uses: kubewarden/github-actions/check-policy-version@v4.1.0
         with:
           expected-version: ${{ steps.calculate-version.outputs.version }}
       - name: Build and annotate policy
-        uses: kubewarden/github-actions/policy-build-tinygo@v4.0.0
+        uses: kubewarden/github-actions/policy-build-tinygo@v4.1.0
       - name: Run e2e tests
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@v4.0.0
+        uses: kubewarden/github-actions/policy-release@v4.1.0
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v4.0.0
+        uses: kubewarden/github-actions/push-artifacthub@v4.1.0
   release-catalog:
     # skip when releasing :latest from main, versions will not match
     if: ${{ inputs.artifacthub && ( ! startsWith(github.ref, 'refs/heads/') ) }} && inputs.release-catalog
@@ -87,6 +87,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Update the Kubewarden policy catalog after a release"
-        uses: kubewarden/github-actions/policy-release-catalog@v4.0.0
+        uses: kubewarden/github-actions/policy-release-catalog@v4.1.0
         with:
           WORKFLOW_PAT: ${{ secrets.WORKFLOW_PAT }}

--- a/.github/workflows/reusable-release-policy-rego.yml
+++ b/.github/workflows/reusable-release-policy-rego.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.0.0
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.1.0
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -76,12 +76,12 @@ jobs:
       - name: Check that `io.kubewarden.policy.version` annotation is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: kubewarden/github-actions/check-policy-version@v4.0.0
+        uses: kubewarden/github-actions/check-policy-version@v4.1.0
         with:
           expected-version: ${{ steps.calculate-version.outputs.version }}
           policy-working-dir: ${{ inputs.policy-working-dir }}
       - name: Install opa
-        uses: kubewarden/github-actions/opa-installer@v4.0.0
+        uses: kubewarden/github-actions/opa-installer@v4.1.0
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Build policy
         working-directory: ${{ inputs.policy-working-dir }}
@@ -99,7 +99,7 @@ jobs:
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@v4.0.0
+        uses: kubewarden/github-actions/policy-release@v4.1.0
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -116,7 +116,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v4.0.0
+        uses: kubewarden/github-actions/push-artifacthub@v4.1.0
         with:
           policy-working-dir: ${{ inputs.policy-working-dir }}
   release-catalog:
@@ -126,7 +126,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Update the Kubewarden policy catalog after a release"
-        uses: kubewarden/github-actions/policy-release-catalog@v4.0.0
+        uses: kubewarden/github-actions/policy-release-catalog@v4.1.0
         with:
           policy-name: ${{ inputs.policy-name }}
           policy-working-dir: ${{ inputs.policy-working-dir }}

--- a/.github/workflows/reusable-release-policy-rego.yml
+++ b/.github/workflows/reusable-release-policy-rego.yml
@@ -11,6 +11,14 @@ on:
         required: false
         type: boolean
         default: true
+      release-catalog:
+        description: "Update the Kubewarden policy catalog after a release"
+        type: boolean
+        default: false
+      policy-name:
+        description: "The name of the policy. This is used in monorepos where multiple policies can be released"
+        required: false
+        type: string
       policy-working-dir:
         description: "working directory of the policy. Useful for repos with policies in folders"
         required: false
@@ -23,6 +31,10 @@ on:
           E.g: tag "v0.1.0", policy-version=0.1.0
         required: false
         type: string
+    secrets:
+      WORKFLOW_PAT:
+        description: "Personal access token used to trigger the policy-catalog workflow"
+        required: false
 
 jobs:
   release:
@@ -107,3 +119,15 @@ jobs:
         uses: kubewarden/github-actions/push-artifacthub@v4.0.0
         with:
           policy-working-dir: ${{ inputs.policy-working-dir }}
+  release-catalog:
+    # skip when releasing :latest from main, versions will not match
+    if: ${{ inputs.artifacthub && ( ! startsWith(github.ref, 'refs/heads/') ) }} && inputs.release-catalog
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Update the Kubewarden policy catalog after a release"
+        uses: kubewarden/github-actions/policy-release-catalog@v4.0.0
+        with:
+          policy-name: ${{ inputs.policy-name }}
+          policy-working-dir: ${{ inputs.policy-working-dir }}
+          WORKFLOW_PAT: ${{ secrets.WORKFLOW_PAT }}

--- a/.github/workflows/reusable-release-policy-rust.yml
+++ b/.github/workflows/reusable-release-policy-rust.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.0.0
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.1.0
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -54,16 +54,16 @@ jobs:
       - name: Check that `io.kubewarden.policy.version` annotation is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: kubewarden/github-actions/check-policy-version@v4.0.0
+        uses: kubewarden/github-actions/check-policy-version@v4.1.0
         with:
           expected-version: ${{ steps.calculate-version.outputs.version }}
       - name: Build and annotate policy
-        uses: kubewarden/github-actions/policy-build-rust@v4.0.0
+        uses: kubewarden/github-actions/policy-build-rust@v4.1.0
       - name: Run e2e tests
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@v4.0.0
+        uses: kubewarden/github-actions/policy-release@v4.1.0
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v4.0.0
+        uses: kubewarden/github-actions/push-artifacthub@v4.1.0
   release-catalog:
     # skip when releasing :latest from main, versions will not match
     if: ${{ inputs.artifacthub && ( ! startsWith(github.ref, 'refs/heads/') ) }} && inputs.release-catalog
@@ -87,6 +87,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Update the Kubewarden policy catalog after a release"
-        uses: kubewarden/github-actions/policy-release-catalog@v4.0.0
+        uses: kubewarden/github-actions/policy-release-catalog@v4.1.0
         with:
           WORKFLOW_PAT: ${{ secrets.WORKFLOW_PAT }}

--- a/.github/workflows/reusable-release-policy-rust.yml
+++ b/.github/workflows/reusable-release-policy-rust.yml
@@ -11,6 +11,14 @@ on:
         required: false
         type: boolean
         default: true
+      release-catalog:
+        description: "Update the Kubewarden policy catalog after a release"
+        type: boolean
+        default: false
+    secrets:
+      WORKFLOW_PAT:
+        description: "Personal access token used to trigger the policy-catalog workflow"
+        required: false
 
 jobs:
   release:
@@ -72,3 +80,13 @@ jobs:
     steps:
       - name: Push artifacthub files to artifacthub branch
         uses: kubewarden/github-actions/push-artifacthub@v4.0.0
+  release-catalog:
+    # skip when releasing :latest from main, versions will not match
+    if: ${{ inputs.artifacthub && ( ! startsWith(github.ref, 'refs/heads/') ) }} && inputs.release-catalog
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Update the Kubewarden policy catalog after a release"
+        uses: kubewarden/github-actions/policy-release-catalog@v4.0.0
+        with:
+          WORKFLOW_PAT: ${{ secrets.WORKFLOW_PAT }}

--- a/.github/workflows/reusable-release-policy-swift.yml
+++ b/.github/workflows/reusable-release-policy-swift.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.0.0
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.1.0
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -54,7 +54,7 @@ jobs:
       - name: Check that `io.kubewarden.policy.version` annotation is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: kubewarden/github-actions/check-policy-version@v4.0.0
+        uses: kubewarden/github-actions/check-policy-version@v4.1.0
         with:
           expected-version: ${{ steps.calculate-version.outputs.version }}
       - name: install wasm-strip
@@ -80,7 +80,7 @@ jobs:
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@v4.0.0
+        uses: kubewarden/github-actions/policy-release@v4.1.0
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -96,7 +96,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v4.0.0
+        uses: kubewarden/github-actions/push-artifacthub@v4.1.0
   release-catalog:
     # skip when releasing :latest from main, versions will not match
     if: ${{ inputs.artifacthub && ( ! startsWith(github.ref, 'refs/heads/') ) }} && inputs.release-catalog
@@ -104,6 +104,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Update the Kubewarden policy catalog after a release"
-        uses: kubewarden/github-actions/policy-release-catalog@v4.0.0
+        uses: kubewarden/github-actions/policy-release-catalog@v4.1.0
         with:
           WORKFLOW_PAT: ${{ secrets.WORKFLOW_PAT }}

--- a/.github/workflows/reusable-release-policy-swift.yml
+++ b/.github/workflows/reusable-release-policy-swift.yml
@@ -11,6 +11,14 @@ on:
         required: false
         type: boolean
         default: true
+      release-catalog:
+        description: "Update the Kubewarden policy catalog after a release"
+        type: boolean
+        default: false
+    secrets:
+      WORKFLOW_PAT:
+        description: "Personal access token used to trigger the policy-catalog workflow"
+        required: false
 
 jobs:
   release:
@@ -89,3 +97,13 @@ jobs:
     steps:
       - name: Push artifacthub files to artifacthub branch
         uses: kubewarden/github-actions/push-artifacthub@v4.0.0
+  release-catalog:
+    # skip when releasing :latest from main, versions will not match
+    if: ${{ inputs.artifacthub && ( ! startsWith(github.ref, 'refs/heads/') ) }} && inputs.release-catalog
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Update the Kubewarden policy catalog after a release"
+        uses: kubewarden/github-actions/policy-release-catalog@v4.0.0
+        with:
+          WORKFLOW_PAT: ${{ secrets.WORKFLOW_PAT }}

--- a/.github/workflows/reusable-test-policy-go-wasi.yml
+++ b/.github/workflows/reusable-test-policy-go-wasi.yml
@@ -23,11 +23,11 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.0.0
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.1.0
       - name: Build and annotate policy
         with:
           generate-sbom: false
-        uses: kubewarden/github-actions/policy-build-go-wasi@v4.0.0
+        uses: kubewarden/github-actions/policy-build-go-wasi@v4.1.0
       - name: Run e2e tests
         run: make e2e-tests
 

--- a/.github/workflows/reusable-test-policy-go.yml
+++ b/.github/workflows/reusable-test-policy-go.yml
@@ -23,11 +23,11 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.0.0
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.1.0
       - name: Build and annotate policy
         with:
           generate-sbom: false
-        uses: kubewarden/github-actions/policy-build-tinygo@v4.0.0
+        uses: kubewarden/github-actions/policy-build-tinygo@v4.1.0
       - name: Run e2e tests
         run: make e2e-tests
 

--- a/.github/workflows/reusable-test-policy-rego.yml
+++ b/.github/workflows/reusable-test-policy-rego.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Install opa
-        uses: kubewarden/github-actions/opa-installer@v4.0.0
+        uses: kubewarden/github-actions/opa-installer@v4.1.0
       - name: Run unit tests
         working-directory: ${{ inputs.policy-working-dir }}
         run: make test

--- a/.github/workflows/reusable-test-policy-rust.yml
+++ b/.github/workflows/reusable-test-policy-rust.yml
@@ -52,11 +52,11 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.0.0
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.1.0
       - name: Build and annotate policy
         with:
           generate-sbom: false
-        uses: kubewarden/github-actions/policy-build-rust@v4.0.0
+        uses: kubewarden/github-actions/policy-build-rust@v4.1.0
       - name: Run e2e tests
         run: |
           make e2e-tests

--- a/policy-gh-action-dependencies/action.yml
+++ b/policy-gh-action-dependencies/action.yml
@@ -9,12 +9,12 @@ runs:
     - name: Install cosign
       uses: sigstore/cosign-installer@d7d6bc7722e3daa8354c50bcb52f4837da5e9b6a # v3
     - name: Install kwctl
-      uses: kubewarden/github-actions/kwctl-installer@v4.0.0
+      uses: kubewarden/github-actions/kwctl-installer@v4.1.0
     - name: Install bats
       uses: mig4/setup-bats@af9a00deb21b5d795cabfeaa8d9060410377686d # v1.2.0
       with:
         bats-version: 1.11.0
     - name: Install SBOM generator tool
-      uses: kubewarden/github-actions/sbom-generator-installer@v4.0.0
+      uses: kubewarden/github-actions/sbom-generator-installer@v4.1.0
     - name: Install SBOM generator tool
-      uses: kubewarden/github-actions/binaryen-installer@v4.0.0
+      uses: kubewarden/github-actions/binaryen-installer@v4.1.0

--- a/policy-release-catalog/action.yml
+++ b/policy-release-catalog/action.yml
@@ -1,0 +1,49 @@
+name: "policy-catalog-release"
+description: "Update the Kubewarden policy catalog after a release"
+branding:
+  icon: "refresh"
+  color: "green"
+inputs:
+  WORKFLOW_PAT:
+    description: "Personal access token used to trigger the policy-catalog workflow"
+    required: true
+    type: string
+  policy-name:
+    description: "The name of the policy. This is used in monorepos where multiple policies can be released"
+    required: false
+    type: string
+  policy-working-dir:
+    description: "working directory of the policy. Useful for repos with policies in folders"
+    required: false
+    type: string
+    default: .
+
+runs:
+  using: "composite"
+  steps:
+    - name: Prepare catalog payload
+      shell: bash
+      id: catalog-payload
+      run: |
+        PAYLOAD='{
+          "owner": "${{ github.repository_owner }}",
+          "repo": "${{ github.event.repository.name }}",
+          "tag": "${{ github.ref_name }}"
+        }'
+
+        if [ -n "${{ inputs.policy-name }}" ]; then
+          PAYLOAD=$(echo $PAYLOAD | jq '. + {"chart_dir": "${{ inputs.policy-name }}"}')
+        fi
+
+        if [ "${{ inputs.policy-working-dir }}" != "." ]; then
+          PAYLOAD=$(echo $PAYLOAD | jq '. + {"artifacthub_pkg_path": "${{ inputs.policy-working-dir }}/artifacthub-pkg.yml"}')
+        fi
+
+        echo "payload=$(echo $PAYLOAD | jq -c)" >> $GITHUB_OUTPUT
+    - name: Update policy catalog
+      uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
+      with:
+        token: ${{ inputs.WORKFLOW_PAT }}
+        repository: kubewarden/policy-catalog
+        event-type: release-policy
+        client-payload: ${{ steps.catalog-payload.outputs.payload }}

--- a/push-artifacthub/action.yml
+++ b/push-artifacthub/action.yml
@@ -22,7 +22,7 @@ runs:
       shell: bash
       working-directory: ${{ inputs.policy-working-dir }}
       run: |
-        kwctl scaffold artifacthub --output /tmp/artifacthub-pkg.yml
+        kwctl scaffold artifacthub --output ${{ runner.temp }}/artifacthub-pkg.yml
     - name: Push up-to-date artifacthub-pkg.yml
       shell: bash
       run: |
@@ -44,7 +44,8 @@ runs:
             
           # checkout the specific files we need from the specific tag that triggered this workflow:
           git checkout ${{ github.ref_name }} -- artifacthub-repo.yml
-          mv /tmp/artifacthub-pkg.yml ${{ inputs.policy-working-dir }}/artifacthub-pkg.yml
+          mkdir -p ${{ inputs.policy-working-dir }}
+          mv ${{ runner.temp }}/artifacthub-pkg.yml ${{ inputs.policy-working-dir }}/artifacthub-pkg.yml
           git checkout ${{ github.ref_name }} -- ${{ inputs.policy-working-dir }}/README.md
           
           # add an commit the needed files:
@@ -61,7 +62,7 @@ runs:
            
           # checkout the specific files we need from the specific tag that triggered this workflow:
           git checkout ${{ github.ref_name }} -- artifacthub-repo.yml
-          mv /tmp/artifacthub-pkg.yml artifacthub-pkg.yml
+          mv ${{ runner.temp }}/artifacthub-pkg.yml artifacthub-pkg.yml
           git checkout ${{ github.ref_name }} -- README.md
 
           # add an commit the needed files:

--- a/push-artifacthub/action.yml
+++ b/push-artifacthub/action.yml
@@ -13,7 +13,7 @@ runs:
   using: "composite"
   steps:
     - name: Install kwctl
-      uses: kubewarden/github-actions/kwctl-installer@v4.0.0
+      uses: kubewarden/github-actions/kwctl-installer@v4.1.0
     - name: Checkout code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       with:


### PR DESCRIPTION
## Description

This PR introduces the necessary repository dispatch for the [policy-catalog](https://github.com/kubewarden/policy-catalog) to update the catalog when a new policy version is released. It includes a new composite action, `policy-release-catalog`, which builds the JSON payload conditionally. If the repository is a monorepo, `policy-name` and `policy-working-dir` are passed accordingly.  

Triggering the workflow requires the `release-catalog` input set to true and the `WORKFLOW_PAT` personal access token passed as a secret., meaning all policies must be updated. 

It also fixes a bug in the `push-artifacthub` composite action, where the directory was not being created during the initial setup of ArtifactHub in a monorepo.

## Test  

Tested in forked repositories:  
- [rego-policies-library](https://github.com/fabriziosestito/rego-policies-library/actions/runs/14029963394)  
- [policy-charts](https://github.com/fabriziosestito/policy-charts/actions/runs/14029977491)