### PR TITLE
fix: skip release catalog if ref is not a tag

### DIFF
--- a/.github/workflows/reusable-release-policy-catalog.yml
+++ b/.github/workflows/reusable-release-policy-catalog.yml
@@ -18,8 +18,8 @@ on:
         required: true
 
 jobs:
-  update-catalog:
-    if: startsWith(github.ref, 'refs/tags/v')
+  release-catalog:
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
     runs-on: ubuntu-latest
     steps:
       - name: Prepare catalog payload
@@ -40,7 +40,7 @@ jobs:
           fi
 
           echo "payload=$(echo $PAYLOAD | jq -c)" >> $GITHUB_OUTPUT
-      - name: Update policy catalog
+      - name: Release policy catalog
         uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
         with:
           token: ${{ secrets.WORKFLOW_PAT }}

--- a/.github/workflows/reusable-release-policy-catalog.yml
+++ b/.github/workflows/reusable-release-policy-catalog.yml
@@ -19,6 +19,7 @@ on:
 
 jobs:
   update-catalog:
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
       - name: Prepare catalog payload


### PR DESCRIPTION
## Description

The release catalog workflow should only be triggered if the ref is a tag. This worked in some repositories, like the monorepo, where tags events triggered the  parent workflow. However, in other repositories, we want to trigger the release of the main branch (latest tag), so this is needed to skip the workflow in that scenario.