### PR TITLE
feat!(release-policy-catalog): generate token programmatically

### DIFF
--- a/.github/workflows/reusable-release-policy-assemblyscript.yml
+++ b/.github/workflows/reusable-release-policy-assemblyscript.yml
@@ -19,7 +19,7 @@ jobs:
       NODE_VERSION: 14
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.2.0
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.3.0
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -48,7 +48,7 @@ jobs:
       - name: Check that `io.kubewarden.policy.version` annotation is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: kubewarden/github-actions/check-policy-version@v4.2.0
+        uses: kubewarden/github-actions/check-policy-version@v4.3.0
         with:
           expected-version: ${{ steps.calculate-version.outputs.version }}
       - name: Setup node
@@ -71,7 +71,7 @@ jobs:
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@v4.2.0
+        uses: kubewarden/github-actions/policy-release@v4.3.0
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -87,4 +87,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v4.2.0
+        uses: kubewarden/github-actions/push-artifacthub@v4.3.0

--- a/.github/workflows/reusable-release-policy-catalog.yml
+++ b/.github/workflows/reusable-release-policy-catalog.yml
@@ -8,13 +8,16 @@ on:
         required: false
         type: string
       policy-working-dir:
-        description: "working directory of the policy. Useful for repos with policies in folders"
+        description: "Working directory of the policy. Useful for repos with policies in folders"
         required: false
         type: string
         default: "."
     secrets:
-      WORKFLOW_PAT:
-        description: "Personal access token used to trigger the policy-catalog workflow"
+      APP_ID:
+        description: "GitHub App ID used to generate a token for the repository dispatch"
+        required: true
+      APP_PRIVATE_KEY:
+        description: "GitHub App Private Key used to generate a token for the repository dispatch"
         required: true
 
 jobs:
@@ -22,6 +25,14 @@ jobs:
     if: ${{ startsWith(github.ref, 'refs/tags/') }}
     runs-on: ubuntu-latest
     steps:
+      - name: Generate token
+        uses: actions/create-github-app-token@af35edadc00be37caa72ed9f3e6d5f7801bfdf09 # v1.11.7
+        id: generate-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          # Set the owner, so the token can be used for cross-repo dispatch
+          owner: ${{ github.repository_owner }}
       - name: Prepare catalog payload
         id: catalog-payload
         run: |
@@ -43,7 +54,7 @@ jobs:
       - name: Release policy catalog
         uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
         with:
-          token: ${{ secrets.WORKFLOW_PAT }}
+          token: ${{ steps.generate-token.outputs.token }}
           repository: kubewarden/policy-catalog
           event-type: release-policy
           client-payload: ${{ steps.catalog-payload.outputs.payload }}

--- a/.github/workflows/reusable-release-policy-go-wasi.yml
+++ b/.github/workflows/reusable-release-policy-go-wasi.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.2.0
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.3.0
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -46,16 +46,16 @@ jobs:
       - name: Check that `io.kubewarden.policy.version` annotation is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: kubewarden/github-actions/check-policy-version@v4.2.0
+        uses: kubewarden/github-actions/check-policy-version@v4.3.0
         with:
           expected-version: ${{ steps.calculate-version.outputs.version }}
       - name: Build and annotate policy
-        uses: kubewarden/github-actions/policy-build-go-wasi@v4.2.0
+        uses: kubewarden/github-actions/policy-build-go-wasi@v4.3.0
       - name: Run e2e tests
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@v4.2.0
+        uses: kubewarden/github-actions/policy-release@v4.3.0
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -71,4 +71,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v4.2.0
+        uses: kubewarden/github-actions/push-artifacthub@v4.3.0

--- a/.github/workflows/reusable-release-policy-go.yml
+++ b/.github/workflows/reusable-release-policy-go.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.2.0
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.3.0
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -46,16 +46,16 @@ jobs:
       - name: Check that `io.kubewarden.policy.version` annotation is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: kubewarden/github-actions/check-policy-version@v4.2.0
+        uses: kubewarden/github-actions/check-policy-version@v4.3.0
         with:
           expected-version: ${{ steps.calculate-version.outputs.version }}
       - name: Build and annotate policy
-        uses: kubewarden/github-actions/policy-build-tinygo@v4.2.0
+        uses: kubewarden/github-actions/policy-build-tinygo@v4.3.0
       - name: Run e2e tests
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@v4.2.0
+        uses: kubewarden/github-actions/policy-release@v4.3.0
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -71,4 +71,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v4.2.0
+        uses: kubewarden/github-actions/push-artifacthub@v4.3.0

--- a/.github/workflows/reusable-release-policy-rego.yml
+++ b/.github/workflows/reusable-release-policy-rego.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.2.0
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.3.0
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -64,12 +64,12 @@ jobs:
       - name: Check that `io.kubewarden.policy.version` annotation is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: kubewarden/github-actions/check-policy-version@v4.2.0
+        uses: kubewarden/github-actions/check-policy-version@v4.3.0
         with:
           expected-version: ${{ steps.calculate-version.outputs.version }}
           policy-working-dir: ${{ inputs.policy-working-dir }}
       - name: Install opa
-        uses: kubewarden/github-actions/opa-installer@v4.2.0
+        uses: kubewarden/github-actions/opa-installer@v4.3.0
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Build policy
         working-directory: ${{ inputs.policy-working-dir }}
@@ -87,7 +87,7 @@ jobs:
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@v4.2.0
+        uses: kubewarden/github-actions/policy-release@v4.3.0
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -104,6 +104,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v4.2.0
+        uses: kubewarden/github-actions/push-artifacthub@v4.3.0
         with:
           policy-working-dir: ${{ inputs.policy-working-dir }}

--- a/.github/workflows/reusable-release-policy-rust.yml
+++ b/.github/workflows/reusable-release-policy-rust.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.2.0
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.3.0
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -46,16 +46,16 @@ jobs:
       - name: Check that `io.kubewarden.policy.version` annotation is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: kubewarden/github-actions/check-policy-version@v4.2.0
+        uses: kubewarden/github-actions/check-policy-version@v4.3.0
         with:
           expected-version: ${{ steps.calculate-version.outputs.version }}
       - name: Build and annotate policy
-        uses: kubewarden/github-actions/policy-build-rust@v4.2.0
+        uses: kubewarden/github-actions/policy-build-rust@v4.3.0
       - name: Run e2e tests
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@v4.2.0
+        uses: kubewarden/github-actions/policy-release@v4.3.0
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -71,4 +71,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v4.2.0
+        uses: kubewarden/github-actions/push-artifacthub@v4.3.0

--- a/.github/workflows/reusable-release-policy-swift.yml
+++ b/.github/workflows/reusable-release-policy-swift.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.2.0
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.3.0
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -46,7 +46,7 @@ jobs:
       - name: Check that `io.kubewarden.policy.version` annotation is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: kubewarden/github-actions/check-policy-version@v4.2.0
+        uses: kubewarden/github-actions/check-policy-version@v4.3.0
         with:
           expected-version: ${{ steps.calculate-version.outputs.version }}
       - name: install wasm-strip
@@ -72,7 +72,7 @@ jobs:
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@v4.2.0
+        uses: kubewarden/github-actions/policy-release@v4.3.0
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -88,4 +88,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v4.2.0
+        uses: kubewarden/github-actions/push-artifacthub@v4.3.0

--- a/.github/workflows/reusable-test-policy-go-wasi.yml
+++ b/.github/workflows/reusable-test-policy-go-wasi.yml
@@ -23,11 +23,11 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.2.0
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.3.0
       - name: Build and annotate policy
         with:
           generate-sbom: false
-        uses: kubewarden/github-actions/policy-build-go-wasi@v4.2.0
+        uses: kubewarden/github-actions/policy-build-go-wasi@v4.3.0
       - name: Run e2e tests
         run: make e2e-tests
 

--- a/.github/workflows/reusable-test-policy-go.yml
+++ b/.github/workflows/reusable-test-policy-go.yml
@@ -23,11 +23,11 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.2.0
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.3.0
       - name: Build and annotate policy
         with:
           generate-sbom: false
-        uses: kubewarden/github-actions/policy-build-tinygo@v4.2.0
+        uses: kubewarden/github-actions/policy-build-tinygo@v4.3.0
       - name: Run e2e tests
         run: make e2e-tests
 

--- a/.github/workflows/reusable-test-policy-rego.yml
+++ b/.github/workflows/reusable-test-policy-rego.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Install opa
-        uses: kubewarden/github-actions/opa-installer@v4.2.0
+        uses: kubewarden/github-actions/opa-installer@v4.3.0
       - name: Run unit tests
         working-directory: ${{ inputs.policy-working-dir }}
         run: make test

--- a/.github/workflows/reusable-test-policy-rust.yml
+++ b/.github/workflows/reusable-test-policy-rust.yml
@@ -52,11 +52,11 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.2.0
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.3.0
       - name: Build and annotate policy
         with:
           generate-sbom: false
-        uses: kubewarden/github-actions/policy-build-rust@v4.2.0
+        uses: kubewarden/github-actions/policy-build-rust@v4.3.0
       - name: Run e2e tests
         run: |
           make e2e-tests

--- a/policy-gh-action-dependencies/action.yml
+++ b/policy-gh-action-dependencies/action.yml
@@ -9,12 +9,12 @@ runs:
     - name: Install cosign
       uses: sigstore/cosign-installer@d7d6bc7722e3daa8354c50bcb52f4837da5e9b6a # v3
     - name: Install kwctl
-      uses: kubewarden/github-actions/kwctl-installer@v4.2.0
+      uses: kubewarden/github-actions/kwctl-installer@v4.3.0
     - name: Install bats
       uses: mig4/setup-bats@af9a00deb21b5d795cabfeaa8d9060410377686d # v1.2.0
       with:
         bats-version: 1.11.0
     - name: Install SBOM generator tool
-      uses: kubewarden/github-actions/sbom-generator-installer@v4.2.0
+      uses: kubewarden/github-actions/sbom-generator-installer@v4.3.0
     - name: Install SBOM generator tool
-      uses: kubewarden/github-actions/binaryen-installer@v4.2.0
+      uses: kubewarden/github-actions/binaryen-installer@v4.3.0

--- a/push-artifacthub/action.yml
+++ b/push-artifacthub/action.yml
@@ -13,7 +13,7 @@ runs:
   using: "composite"
   steps:
     - name: Install kwctl
-      uses: kubewarden/github-actions/kwctl-installer@v4.2.0
+      uses: kubewarden/github-actions/kwctl-installer@v4.3.0
     - name: Checkout code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       with:


### PR DESCRIPTION
## Description  
This PR replaces the `WORKFLOW_PAT` secret with the [create-github-app-token action](https://github.com/actions/create-github-app-token?tab=readme-ov-file#create-a-token-for-all-repositories-in-another-owners-installation).  
Related to https://github.com/kubewarden/kubewarden-controller/issues/1070
It now requires `APP_ID` and `APP_PRIVATE_KEY` as secrets.  

This is a breaking change since it modifies the required input secrets.

