### PR TITLE
ci: Reuse GH draft release when creating GH release

### DIFF
--- a/check-policy-version/action.yml
+++ b/check-policy-version/action.yml
@@ -7,11 +7,9 @@ inputs:
   expected-version:
     description: "The expected value of the version annotation. E.g: 0.1.0"
     required: true
-    type: string
   policy-working-dir:
     description: "working directory of the policy. Useful for repos with policies in folders"
     required: false
-    type: string
     default: .
 runs:
   using: "composite"

--- a/policy-release/action.yml
+++ b/policy-release/action.yml
@@ -11,20 +11,16 @@ inputs:
   oci-target:
     description: "OCI target repository for the resulting policy artifact"
     required: true
-    type: string
   GITHUB_TOKEN:
     description: "GitHub token to login into ghcr.io"
     required: true
-    type: string
   policy-working-dir:
     description: "working directory of the policy. Useful for repos with policies in folders"
     required: false
-    type: string
     default: .
   policy-version:
     description: "release version of the policy without `v` prefix. E.g: 0.1.0"
     required: true
-    type: string
 
 runs:
   using: "composite"

--- a/policy-release/action.yml
+++ b/policy-release/action.yml
@@ -58,18 +58,65 @@ runs:
 
         echo Keyless signing of policy using cosign
         cosign sign --yes ${IMMUTABLE_REF}
-    - name: Create release
+    - name: Get release ID from the release created by release drafter
       if: ${{ ! startsWith(github.ref, 'refs/heads/') }}
-      uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1
-      env:
-        GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
       with:
-        tag_name: ${{ github.ref }}
-        name: ${{ github.ref_name }}
-        draft: false
-        prerelease: ${{ contains(inputs.policy-version, '-alpha') || contains(inputs.policy-version, '-beta') || contains(inputs.policy-version, '-rc') }}
-        files: |
-          ${{ inputs.policy-working-dir }}/policy.wasm
-          ${{ inputs.policy-working-dir }}/policy-sbom.spdx.json
-          ${{ inputs.policy-working-dir }}/policy-sbom.spdx.cert
-          ${{ inputs.policy-working-dir }}/policy-sbom.spdx.sig
+        script: |
+          let releases = await github.rest.repos.listReleases({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+          });
+          for (const release of releases.data) {
+            if (release.draft) {
+                    core.info(release)
+                    core.exportVariable('RELEASE_ID', release.id)
+                    return
+            }
+          }
+          core.setFailed(`Draft release not found`)
+    - name: Upload release assets
+      if: ${{ ! startsWith(github.ref, 'refs/heads/') }}
+      id: upload_release_assets
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+      with:
+        script: |
+          let fs = require('fs');
+          let path = require('path');
+
+          let files = [
+            'policy.wasm',
+            'policy-sbom.spdx.json',
+            'policy-sbom.spdx.cert',
+            'policy-sbom.spdx.sig']
+          const {RELEASE_ID} = process.env
+
+          for (const file of files) {
+            let file_data = fs.readFileSync(file);
+
+            let response = await github.rest.repos.uploadReleaseAsset({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: `${RELEASE_ID}`,
+              name: path.basename(file),
+              data: file_data,
+            });
+          }
+    - name: Publish release
+      if: ${{ ! startsWith(github.ref, 'refs/heads/') }}
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+      with:
+        script: |
+          const {RELEASE_ID} = process.env
+          const TAG_NAME = "${{ github.ref_name }}";
+          isPreRelease = ${{ contains(github.ref_name, '-alpha') || contains(github.ref_name, '-beta') || contains(github.ref_name, '-rc') }}
+          github.rest.repos.updateRelease({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            release_id: `${RELEASE_ID}`,
+            draft: false,
+            tag_name: TAG_NAME,
+            name: TAG_NAME,
+            prerelease: isPreRelease,
+            make_latest: !isPreRelease
+          });

--- a/push-artifacthub/action.yml
+++ b/push-artifacthub/action.yml
@@ -7,7 +7,6 @@ inputs:
   policy-working-dir:
     description: "working directory of the policy. Useful for repos with policies in folders"
     required: false
-    type: string
     default: .
 runs:
   using: "composite"


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix https://github.com/kubewarden/github-actions/issues/180

This change reuses the existing GH draft release when releasing the
policy, as the draft release was created by release-drafter and
contains the changelog.

The steps upload the release artifacts to the GH release and update the
GH release setting it as latest.



<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Tested by releasing an RC of a policy:
https://github.com/kubewarden/verify-image-signatures/actions/runs/14380246089/job/40322221198
Which resulted on:
https://github.com/kubewarden/verify-image-signatures/releases/tag/v0.3.3-rc1

Also, here's the run for the main branch (without the tag) which correctly builds the image but skips creating a GH release:
https://github.com/kubewarden/verify-image-signatures/actions/runs/14384233285

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
