### PR TITLE
ci(release-policy-catalog): replace artifacthub_pkg_path with policy_working_dir

### DIFF
--- a/.github/workflows/reusable-release-policy-catalog.yml
+++ b/.github/workflows/reusable-release-policy-catalog.yml
@@ -47,7 +47,7 @@ jobs:
           fi
 
           if [ "${{ inputs.policy-working-dir }}" != "." ]; then
-            PAYLOAD=$(echo $PAYLOAD | jq '. + {"artifacthub_pkg_path": "${{ inputs.policy-working-dir }}/artifacthub-pkg.yml"}')
+            PAYLOAD=$(echo $PAYLOAD | jq '. + {"policy_working_dir": "${{ inputs.policy-working-dir }}"}')
           fi
 
           echo "payload=$(echo $PAYLOAD | jq -c)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Description

Replaces `artifacthub_pkg_path` with `policy_working_dir`

related to https://github.com/kubewarden/policy-catalog/pull/379 and https://github.com/kubewarden/policy-catalog/issues/345