### PR TITLE
fix: Don't use GH draft releases on monorepos

### DIFF
--- a/.github/workflows/reusable-release-policy-assemblyscript.yml
+++ b/.github/workflows/reusable-release-policy-assemblyscript.yml
@@ -19,7 +19,7 @@ jobs:
       NODE_VERSION: 14
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.4.3
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.4.4
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -48,11 +48,11 @@ jobs:
       - name: Check that `io.kubewarden.policy.version` annotation is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: kubewarden/github-actions/check-policy-version@v4.4.3
+        uses: kubewarden/github-actions/check-policy-version@v4.4.4
         with:
           expected-version: ${{ steps.calculate-version.outputs.version }}
       - name: Setup node
-        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.4.3
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.4.4
         with:
           node-version: "${{ env.NODE_VERSION }}"
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -71,7 +71,7 @@ jobs:
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@v4.4.3
+        uses: kubewarden/github-actions/policy-release@v4.4.4
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -87,4 +87,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v4.4.3
+        uses: kubewarden/github-actions/push-artifacthub@v4.4.4

--- a/.github/workflows/reusable-release-policy-go-wasi.yml
+++ b/.github/workflows/reusable-release-policy-go-wasi.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.4.3
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.4.4
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -46,16 +46,16 @@ jobs:
       - name: Check that `io.kubewarden.policy.version` annotation is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: kubewarden/github-actions/check-policy-version@v4.4.3
+        uses: kubewarden/github-actions/check-policy-version@v4.4.4
         with:
           expected-version: ${{ steps.calculate-version.outputs.version }}
       - name: Build and annotate policy
-        uses: kubewarden/github-actions/policy-build-go-wasi@v4.4.3
+        uses: kubewarden/github-actions/policy-build-go-wasi@v4.4.4
       - name: Run e2e tests
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@v4.4.3
+        uses: kubewarden/github-actions/policy-release@v4.4.4
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -71,4 +71,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v4.4.3
+        uses: kubewarden/github-actions/push-artifacthub@v4.4.4

--- a/.github/workflows/reusable-release-policy-go.yml
+++ b/.github/workflows/reusable-release-policy-go.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.4.3
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.4.4
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -46,16 +46,16 @@ jobs:
       - name: Check that `io.kubewarden.policy.version` annotation is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: kubewarden/github-actions/check-policy-version@v4.4.3
+        uses: kubewarden/github-actions/check-policy-version@v4.4.4
         with:
           expected-version: ${{ steps.calculate-version.outputs.version }}
       - name: Build and annotate policy
-        uses: kubewarden/github-actions/policy-build-tinygo@v4.4.3
+        uses: kubewarden/github-actions/policy-build-tinygo@v4.4.4
       - name: Run e2e tests
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@v4.4.3
+        uses: kubewarden/github-actions/policy-release@v4.4.4
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -71,4 +71,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v4.4.3
+        uses: kubewarden/github-actions/push-artifacthub@v4.4.4

--- a/.github/workflows/reusable-release-policy-rego.yml
+++ b/.github/workflows/reusable-release-policy-rego.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.4.3
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.4.4
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -64,12 +64,12 @@ jobs:
       - name: Check that `io.kubewarden.policy.version` annotation is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: kubewarden/github-actions/check-policy-version@v4.4.3
+        uses: kubewarden/github-actions/check-policy-version@v4.4.4
         with:
           expected-version: ${{ steps.calculate-version.outputs.version }}
           policy-working-dir: ${{ inputs.policy-working-dir }}
       - name: Install opa
-        uses: kubewarden/github-actions/opa-installer@v4.4.3
+        uses: kubewarden/github-actions/opa-installer@v4.4.4
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Build policy
         working-directory: ${{ inputs.policy-working-dir }}
@@ -87,7 +87,7 @@ jobs:
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@v4.4.3
+        uses: kubewarden/github-actions/policy-release@v4.4.4
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -104,6 +104,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v4.4.3
+        uses: kubewarden/github-actions/push-artifacthub@v4.4.4
         with:
           policy-working-dir: ${{ inputs.policy-working-dir }}

--- a/.github/workflows/reusable-release-policy-rust.yml
+++ b/.github/workflows/reusable-release-policy-rust.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.4.3
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.4.4
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -46,16 +46,16 @@ jobs:
       - name: Check that `io.kubewarden.policy.version` annotation is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: kubewarden/github-actions/check-policy-version@v4.4.3
+        uses: kubewarden/github-actions/check-policy-version@v4.4.4
         with:
           expected-version: ${{ steps.calculate-version.outputs.version }}
       - name: Build and annotate policy
-        uses: kubewarden/github-actions/policy-build-rust@v4.4.3
+        uses: kubewarden/github-actions/policy-build-rust@v4.4.4
       - name: Run e2e tests
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@v4.4.3
+        uses: kubewarden/github-actions/policy-release@v4.4.4
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -71,4 +71,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v4.4.3
+        uses: kubewarden/github-actions/push-artifacthub@v4.4.4

--- a/.github/workflows/reusable-release-policy-swift.yml
+++ b/.github/workflows/reusable-release-policy-swift.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.4.3
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.4.4
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -46,7 +46,7 @@ jobs:
       - name: Check that `io.kubewarden.policy.version` annotation is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: kubewarden/github-actions/check-policy-version@v4.4.3
+        uses: kubewarden/github-actions/check-policy-version@v4.4.4
         with:
           expected-version: ${{ steps.calculate-version.outputs.version }}
       - name: install wasm-strip
@@ -72,7 +72,7 @@ jobs:
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@v4.4.3
+        uses: kubewarden/github-actions/policy-release@v4.4.4
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -88,4 +88,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v4.4.3
+        uses: kubewarden/github-actions/push-artifacthub@v4.4.4

--- a/.github/workflows/reusable-test-policy-assemblyscript.yml
+++ b/.github/workflows/reusable-test-policy-assemblyscript.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup node
-        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.4.3
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.4.4
         with:
           node-version: "${{ env.NODE_VERSION }}"
       - name: Install npm

--- a/.github/workflows/reusable-test-policy-go-wasi.yml
+++ b/.github/workflows/reusable-test-policy-go-wasi.yml
@@ -23,11 +23,11 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.4.3
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.4.4
       - name: Build and annotate policy
         with:
           generate-sbom: false
-        uses: kubewarden/github-actions/policy-build-go-wasi@v4.4.3
+        uses: kubewarden/github-actions/policy-build-go-wasi@v4.4.4
       - name: Run e2e tests
         run: make e2e-tests
 

--- a/.github/workflows/reusable-test-policy-go.yml
+++ b/.github/workflows/reusable-test-policy-go.yml
@@ -23,11 +23,11 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.4.3
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.4.4
       - name: Build and annotate policy
         with:
           generate-sbom: false
-        uses: kubewarden/github-actions/policy-build-tinygo@v4.4.3
+        uses: kubewarden/github-actions/policy-build-tinygo@v4.4.4
       - name: Run e2e tests
         run: make e2e-tests
 

--- a/.github/workflows/reusable-test-policy-rego.yml
+++ b/.github/workflows/reusable-test-policy-rego.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install opa
-        uses: kubewarden/github-actions/opa-installer@v4.4.3
+        uses: kubewarden/github-actions/opa-installer@v4.4.4
       - name: Run unit tests
         working-directory: ${{ inputs.policy-working-dir }}
         run: make test

--- a/.github/workflows/reusable-test-policy-rust.yml
+++ b/.github/workflows/reusable-test-policy-rust.yml
@@ -52,11 +52,11 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.4.3
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.4.4
       - name: Build and annotate policy
         with:
           generate-sbom: false
-        uses: kubewarden/github-actions/policy-build-rust@v4.4.3
+        uses: kubewarden/github-actions/policy-build-rust@v4.4.4
       - name: Run e2e tests
         run: |
           make e2e-tests

--- a/policy-gh-action-dependencies/action.yml
+++ b/policy-gh-action-dependencies/action.yml
@@ -9,12 +9,12 @@ runs:
     - name: Install cosign
       uses: sigstore/cosign-installer@d7d6bc7722e3daa8354c50bcb52f4837da5e9b6a # v3.8.1
     - name: Install kwctl
-      uses: kubewarden/github-actions/kwctl-installer@v4.4.3
+      uses: kubewarden/github-actions/kwctl-installer@v4.4.4
     - name: Install bats
       uses: mig4/setup-bats@af9a00deb21b5d795cabfeaa8d9060410377686d # v1.2.0
       with:
         bats-version: 1.11.0
     - name: Install SBOM generator tool
-      uses: kubewarden/github-actions/sbom-generator-installer@v4.4.3
+      uses: kubewarden/github-actions/sbom-generator-installer@v4.4.4
     - name: Install SBOM generator tool
-      uses: kubewarden/github-actions/binaryen-installer@v4.4.3
+      uses: kubewarden/github-actions/binaryen-installer@v4.4.4

--- a/policy-release/action.yml
+++ b/policy-release/action.yml
@@ -54,8 +54,24 @@ runs:
 
         echo Keyless signing of policy using cosign
         cosign sign --yes ${IMMUTABLE_REF}
+    - name: Create release
+      if: ${{ ! startsWith(github.ref, 'refs/heads/')  && inputs.policy-working-dir != '.' }}
+      # if we are on a monorepo, we create a GH release directly and don't reuse a draft release
+      uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1
+      env:
+        GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        name: ${{ github.ref_name }}
+        draft: false
+        prerelease: ${{ contains(inputs.policy-version, '-alpha') || contains(inputs.policy-version, '-beta') || contains(inputs.policy-version, '-rc') }}
+        files: |
+          ${{ inputs.policy-working-dir }}/policy.wasm
+
     - name: Get release ID from the release created by release drafter
-      if: ${{ ! startsWith(github.ref, 'refs/heads/') }}
+      if: ${{ ! startsWith(github.ref, 'refs/heads/')  && inputs.policy-working-dir == '.' }}
+      # if we are on a single repo, we obtain the last draft release as it contains the changelog
+      # and edit it by adding the artifacts. Then we mark the release as latest
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
       with:
         script: |
@@ -72,7 +88,9 @@ runs:
           }
           core.setFailed(`Draft release not found`)
     - name: Upload release assets
-      if: ${{ ! startsWith(github.ref, 'refs/heads/') }}
+      if: ${{ ! startsWith(github.ref, 'refs/heads/')  && inputs.policy-working-dir == '.' }}
+      # if we are on a single repo, we obtain the last draft release as it contains the changelog
+      # and edit it by adding the artifacts. Then we mark the release as latest
       id: upload_release_assets
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
       env:
@@ -85,9 +103,6 @@ runs:
 
           let files = [
             `${workingDir}/policy.wasm`,
-            `${workingDir}/policy-sbom.spdx.json`,
-            `${workingDir}/policy-sbom.spdx.cert`,
-            `${workingDir}/policy-sbom.spdx.sig`]
           const {RELEASE_ID} = process.env
 
           for (const file of files) {
@@ -102,7 +117,9 @@ runs:
             });
           }
     - name: Publish release
-      if: ${{ ! startsWith(github.ref, 'refs/heads/') }}
+      if: ${{ ! startsWith(github.ref, 'refs/heads/')  && inputs.policy-working-dir == '.' }}
+      # if we are on a single repo, we obtain the last draft release as it contains the changelog
+      # and edit it by adding the artifacts. Then we mark the release as latest
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
       with:
         script: |

--- a/push-artifacthub/action.yml
+++ b/push-artifacthub/action.yml
@@ -12,7 +12,7 @@ runs:
   using: "composite"
   steps:
     - name: Install kwctl
-      uses: kubewarden/github-actions/kwctl-installer@v4.4.3
+      uses: kubewarden/github-actions/kwctl-installer@v4.4.4
     - name: Checkout code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:


### PR DESCRIPTION
## Description

Fixes errors such as https://github.com/kubewarden/rego-policies-library/actions/runs/14491317023/job/40649089321#step:11:112

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
uh?

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
