### PR TITLE
ci: Substitute peter-evans/repository-dispatch with gh cli

### DIFF
--- a/.github/workflows/reusable-release-policy-catalog.yml
+++ b/.github/workflows/reusable-release-policy-catalog.yml
@@ -36,25 +36,32 @@ jobs:
       - name: Prepare catalog payload
         id: catalog-payload
         run: |
-          PAYLOAD='{
-            "owner": "${{ github.repository_owner }}",
-            "repo": "${{ github.event.repository.name }}",
-            "tag": "${{ github.ref_name }}"
-          }'
+          PAYLOAD=$(jq -n \
+            --arg owner "${{ github.repository_owner }}" \
+            --arg repo "${{ github.event.repository.name }}" \
+            --arg tag "${{ github.ref_name }}" \
+            '{
+              event_type: "release-policy",
+              client_payload: {
+                owner: $owner,
+                repo: $repo,
+                tag: $tag
+              }
+            }')
 
           if [ -n "${{ inputs.policy-name }}" ]; then
-            PAYLOAD=$(echo $PAYLOAD | jq '. + {"chart_dir": "${{ inputs.policy-name }}"}')
+            PAYLOAD=$(echo "$PAYLOAD" | jq --arg chart_dir "${{ inputs.policy-name }}" '.client_payload.chart_dir = $chart_dir')
           fi
 
           if [ "${{ inputs.policy-working-dir }}" != "." ]; then
-            PAYLOAD=$(echo $PAYLOAD | jq '. + {"policy_working_dir": "${{ inputs.policy-working-dir }}"}')
+            PAYLOAD=$(echo "$PAYLOAD" | jq --arg policy_working_dir "${{ inputs.policy-working-dir }}" '.client_payload.policy_working_dir = $policy_working_dir')
           fi
 
-          echo "payload=$(echo $PAYLOAD | jq -c)" >> $GITHUB_OUTPUT
+          echo "payload=$PAYLOAD" >> payload.json
       - name: Release policy catalog
-        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
-        with:
-          token: ${{ steps.generate-token.outputs.token }}
-          repository: kubewarden/policy-catalog
-          event-type: release-policy
-          client-payload: ${{ steps.catalog-payload.outputs.payload }}
+        env:
+          GH_TOKEN: ${{ secrets.WORKFLOW_PAT }}
+        run: |
+          gh api repos/${{ github.repository_owner }}/policy-catalog/dispatches \
+            -X POST \
+            --input payload.json


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
<!-- Please provide the link to the GitHub issue you are addressing -->
Part of https://github.com/kubewarden/kubewarden-controller/issues/1099.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Tested locally with:
```console
$ cat payload.json
{
  "event_type": "release-policy",
  "client_payload": {
    "owner": "viccuad",
    "repo": "deprecated-api-versions-policy",
    "tag": "v1.0.0"
  }
}

$ gh api repos/viccuad/policy-catalog/dispatches -X POST  --input payload.json

```


<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
