### PR TITLE
fix: syntax error in policy-release action.

### DIFF
--- a/policy-release/action.yml
+++ b/policy-release/action.yml
@@ -103,6 +103,7 @@ runs:
 
           let files = [
             `${workingDir}/policy.wasm`,
+          ]
           const {RELEASE_ID} = process.env
 
           for (const file of files) {


### PR DESCRIPTION
## Description

In a previous commit (93fc9b2ceeb5d87d13ee52254b48fc8b11c4e64a) the "]" closing the array has been removed accidentally. This commit fix this syntax error.

