### PR TITLE
fix(kwctl-installer): install v1.27.0-alpha2

### DIFF
--- a/kwctl-installer/action.yml
+++ b/kwctl-installer/action.yml
@@ -7,7 +7,7 @@ inputs:
   KWCTL_VERSION:
     description: "kwctl release to be installed"
     required: false
-    default: v1.27.0-alpha1
+    default: v1.27.0-alpha2
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
## Description

To allow the release of the new high risk service account blocker policy, we need to update the kwctl installed to v1.27.0-alpha2. It has the kubernetes/can-i host capability with the correct input and output json
