### PR TITLE
fix(kwctl): updates kwctl version in use.

### DIFF
--- a/kwctl-installer/action.yml
+++ b/kwctl-installer/action.yml
@@ -7,7 +7,7 @@ inputs:
   KWCTL_VERSION:
     description: "kwctl release to be installed"
     required: false
-    default: v1.27.0-alpha3
+    default: v1.28.1
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
## Description

Updates the kwctl installer updating the default kwctl version installed to v1.28.1.

This is required to make CI on this [PR](https://github.com/kubewarden/policy-sdk-js/pull/189) happy

