### PR TITLE
fix(build-rust): override current toolchain.

### DIFF
--- a/policy-build-rust/action.yml
+++ b/policy-build-rust/action.yml
@@ -19,6 +19,7 @@ runs:
       shell: bash
       run: |
         rustup toolchain install stable  --profile minimal --target wasm32-wasip1
+        rustup override set stable
     - name: Build Wasm module
       shell: bash
       run: cargo build --target=wasm32-wasip1 --release


### PR DESCRIPTION
## Description

Updates the policy-build-rust action to override the toolchain in the working directory to ensure that the following build command will use the toolchain with the wasm32-wasip1 target. This was found during the debugging of some failing [PRs](https://github.com/kubewarden/verify-image-signatures/pull/218). 

I'm not sure why we are seeing this only now. I've try to see something in rustup/gihub runner image changes. But I did not find anything obvious yet. 

In the example below is possible to see that even after the toolchain installation the active toolchain in the policy directory is not the latest stable (1.90) is the previous one already installed in the runner (1.89). That's why the `rustup override set stable` call is necessary in the policy. Therefore, the action follow the partner used in other [steps](https://github.com/kubewarden/github-actions/blob/0c3d96f5251f687de1bbe1cd29e86b8a47bd17a6/.github/workflows/reusable-test-policy-rust.yml#L45) of the reusable workflows. 


```
rustup toolchain install stable  --profile minimal --target wasm32-wasip1
rustup show
rustup target list
shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
info: syncing channel updates for 'stable-x86_64-unknown-linux-gnu'
info: latest update on 2025-09-18, rust version 1.90.0 (1159e78c4 2025-09-14)
info: downloading component 'cargo'
info: downloading component 'rust-std' for 'wasm32-wasip1'
info: downloading component 'rust-std'
info: downloading component 'rustc'
info: installing component 'cargo'
info: installing component 'rust-std' for 'wasm32-wasip1'
info: installing component 'rust-std'
info: installing component 'rustc'
  stable-x86_64-unknown-linux-gnu installed - rustc 1.90.0 (1159e78c4 2025-09-14)
Default host: x86_64-unknown-linux-gnu
rustup home:  /home/runner/.rustup
installed toolchains
--------------------
stable-x86_64-unknown-linux-gnu
1.89.0-x86_64-unknown-linux-gnu (active, default)
active toolchain
----------------
name: 1.89.0-x86_64-unknown-linux-gnu
active because: it's the default toolchain
installed targets:
  x86_64-unknown-linux-gnu
aarch64-apple-darwin
aarch64-apple-ios
aarch64-apple-ios-macabi
aarch64-apple-ios-sim
aarch64-linux-android
aarch64-pc-windows-gnullvm
aarch64-pc-windows-msvc
aarch64-unknown-fuchsia
aarch64-unknown-linux-gnu
aarch64-unknown-linux-musl
aarch64-unknown-linux-ohos
aarch64-unknown-none
aarch64-unknown-none-softfloat
aarch64-unknown-uefi
arm-linux-androideabi
arm-unknown-linux-gnueabi
arm-unknown-linux-gnueabihf
arm-unknown-linux-musleabi
arm-unknown-linux-musleabihf
arm64ec-pc-windows-msvc
armebv7r-none-eabi
armebv7r-none-eabihf
armv5te-unknown-linux-gnueabi
armv5te-unknown-linux-musleabi
armv7-linux-androideabi
armv7-unknown-linux-gnueabi
armv7-unknown-linux-gnueabihf
armv7-unknown-linux-musleabi
armv7-unknown-linux-musleabihf
armv7-unknown-linux-ohos
armv7a-none-eabi
armv7r-none-eabi
armv7r-none-eabihf
i586-unknown-linux-gnu
i586-unknown-linux-musl
i686-linux-android
i686-pc-windows-gnu
i686-pc-windows-gnullvm
i686-pc-windows-msvc
i686-unknown-freebsd
i686-unknown-linux-gnu
i686-unknown-linux-musl
i686-unknown-uefi
loongarch64-unknown-linux-gnu
loongarch64-unknown-linux-musl
loongarch64-unknown-none
loongarch64-unknown-none-softfloat
nvptx64-nvidia-cuda
powerpc-unknown-linux-gnu
powerpc64-unknown-linux-gnu
powerpc64le-unknown-linux-gnu
powerpc64le-unknown-linux-musl
riscv32i-unknown-none-elf
riscv32im-unknown-none-elf
riscv32imac-unknown-none-elf
riscv32imafc-unknown-none-elf
riscv32imc-unknown-none-elf
riscv64gc-unknown-linux-gnu
riscv64gc-unknown-linux-musl
riscv64gc-unknown-none-elf
riscv64imac-unknown-none-elf
s390x-unknown-linux-gnu
sparc64-unknown-linux-gnu
sparcv9-sun-solaris
thumbv6m-none-eabi
thumbv7em-none-eabi
thumbv7em-none-eabihf
thumbv7m-none-eabi
thumbv7neon-linux-androideabi
thumbv7neon-unknown-linux-gnueabihf
thumbv8m.base-none-eabi
thumbv8m.main-none-eabi
thumbv8m.main-none-eabihf
wasm32-unknown-emscripten
wasm32-unknown-unknown
wasm32-wasip1
wasm32-wasip1-threads
wasm32-wasip2
wasm32v1-none
x86_64-apple-darwin
x86_64-apple-ios
x86_64-apple-ios-macabi
x86_64-fortanix-unknown-sgx
x86_64-linux-android
x86_64-pc-solaris
x86_64-pc-windows-gnu
x86_64-pc-windows-gnullvm
x86_64-pc-windows-msvc
x86_64-unknown-freebsd
x86_64-unknown-fuchsia
x86_64-unknown-illumos
x86_64-unknown-linux-gnu (installed)
x86_64-unknown-linux-gnux32
x86_64-unknown-linux-musl
x86_64-unknown-linux-ohos
x86_64-unknown-netbsd
x86_64-unknown-none
x86_64-unknown-redox
x86_64-unknown-uefi
Run cargo build --target=wasm32-wasip1 --release
[...]
   Compiling stable_deref_trait v1.2.0
error[E0463]: can't find crate for `core`
  |
  = note: the `wasm32-wasip1` target may not be installed
  = help: consider downloading the target with `rustup target add wasm32-wasip1`
For more information about this error, try `rustc --explain E0463`.
error: could not compile `stable_deref_trait` (lib) due to 1 previous error
```



