### PR TITLE
fix(ci): disable new cosign signature bundle format.

### DIFF
--- a/policy-build-go-wasi/action.yml
+++ b/policy-build-go-wasi/action.yml
@@ -41,7 +41,12 @@ runs:
       if: ${{ inputs.generate-sbom == 'true' }}
       shell: bash
       run: |
-        cosign sign-blob --yes --output-certificate policy-sbom.spdx.cert \
+
+        # We need to disable the new bundle format enabled by default since 
+        # cosign v3.x.x because some verification tools (e.g. slsactl) are not
+        # able to properly verify the signatures using this new format
+        cosign sign-blob --yes --new-bundle-format=false --use-signing-config=false \
+          --output-certificate policy-sbom.spdx.cert \
           --output-signature policy-sbom.spdx.sig \
           policy-sbom.spdx.json
     - name: Upload policy SBOM files

--- a/policy-build-rust/action.yml
+++ b/policy-build-rust/action.yml
@@ -46,7 +46,11 @@ runs:
       if: ${{ inputs.generate-sbom == 'true' }}
       shell: bash
       run: |
-        cosign sign-blob --yes --output-certificate policy-sbom.spdx.cert \
+        # We need to disable the new bundle format enabled by default since 
+        # cosign v3.x.x because some verification tools (e.g. slsactl) are not
+        # able to properly verify the signatures using this new format
+        cosign sign-blob --yes --new-bundle-format=false --use-signing-config=false \
+          --output-certificate policy-sbom.spdx.cert \
           --output-signature policy-sbom.spdx.sig \
           policy-sbom.spdx.json
     - name: Upload policy SBOM files

--- a/policy-build-tinygo/action.yml
+++ b/policy-build-tinygo/action.yml
@@ -53,7 +53,11 @@ runs:
       if: ${{ inputs.generate-sbom == 'true' }}
       shell: bash
       run: |
-        cosign sign-blob --yes --output-certificate policy-sbom.spdx.cert \
+        # We need to disable the new bundle format enabled by default since 
+        # cosign v3.x.x because some verification tools (e.g. slsactl) are not
+        # able to properly verify the signatures using this new format
+        cosign sign-blob --yes --new-bundle-format=false --use-signing-config=false \
+          --output-certificate policy-sbom.spdx.cert \
           --output-signature policy-sbom.spdx.sig \
           policy-sbom.spdx.json
     - name: Upload policy SBOM files

--- a/policy-release/action.yml
+++ b/policy-release/action.yml
@@ -46,7 +46,10 @@ runs:
         IMMUTABLE_REF=$(kwctl push -o json ${{ inputs.annotated-wasm }} ${{ inputs.oci-target }}:latest | jq -r .immutable_ref)
 
         echo Keyless signing of policy using cosign
-        cosign sign --yes ${IMMUTABLE_REF}
+        # We need to disable the new bundle format enabled by default since 
+        # cosign v3.x.x because some verification tools (e.g. slsactl) are not
+        # able to properly verify the signatures using this new format
+        cosign sign --yes --new-bundle-format=false --use-signing-config=false ${IMMUTABLE_REF}
     - name: Publish Wasm policy artifact to OCI registry with the version tag and 'latest'
       shell: bash
       if: ${{ ! startsWith(github.ref, 'refs/heads/') }}
@@ -59,7 +62,10 @@ runs:
         IMMUTABLE_REF=$(kwctl push -o json ${{ inputs.annotated-wasm }} ${{ inputs.oci-target }}:${OCI_TAG} | jq -r .immutable_ref)
 
         echo Keyless signing of policy using cosign
-        cosign sign --yes ${IMMUTABLE_REF}
+        # We need to disable the new bundle format enabled by default since 
+        # cosign v3.x.x because some verification tools (e.g. slsactl) are not
+        # able to properly verify the signatures using this new format
+        cosign sign --yes --new-bundle-format=false --use-signing-config=false ${IMMUTABLE_REF}
     - name: Create release
       if: ${{ ! startsWith(github.ref, 'refs/heads/')  && inputs.policy-working-dir != '.' }}
       # if we are on a monorepo, we create a GH release directly and don't reuse a draft release


### PR DESCRIPTION
## Description

In order to allow old cosign version and other verification tools to verify the signature it's necessary to disable the new cosign signature bundle enable by default since v3.x.x.

Fix https://github.com/kubewarden/helm-charts/issues/839

Without this change, kwctl/policy server will not be able to fetch policies signatures:

```bash
$ kwctl inspect --show-signatures registry://ghcr.io/jvanz/policies/pod-privileged:v2.0.0 #testing policy
[...]
2025-10-24T19:38:55.270165Z  INFO sigstore::cosign::client_builder: No Fulcio cert has been provided. Fulcio integration disabled

Cannot determine if the policy has been signed. There was an error while attempting to fetch its signatures from the remote registry: Fail to interact with OCI registry: Registry error: url https://ghcr.io/v2/jvanz/policies/pod-privileged/manifests/sha256-45cd91d76c819c1381afcb2e24c968e04f24350fa28242782952b81ac1c2b30b.sig, envelope: OCI API errors: [OCI API error: manifest unknown] 
```

