### PR TITLE
fix(ci): add second cosign signature for compatibility

### DIFF
--- a/policy-build-go-wasi/action.yml
+++ b/policy-build-go-wasi/action.yml
@@ -37,18 +37,16 @@ runs:
       shell: bash
       run: |
         make annotated-policy.wasm
+
     - name: Sign BOM file
       if: ${{ inputs.generate-sbom == 'true' }}
       shell: bash
       run: |
-
-        # We need to disable the new bundle format enabled by default since 
-        # cosign v3.x.x because some verification tools (e.g. slsactl) are not
-        # able to properly verify the signatures using this new format
-        cosign sign-blob --yes --new-bundle-format=false --use-signing-config=false \
+        cosign sign-blob --yes \
           --output-certificate policy-sbom.spdx.cert \
           --output-signature policy-sbom.spdx.sig \
           policy-sbom.spdx.json
+
     - name: Upload policy SBOM files
       if: ${{ inputs.generate-sbom == 'true' }}
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0

--- a/policy-build-rust/action.yml
+++ b/policy-build-rust/action.yml
@@ -46,13 +46,11 @@ runs:
       if: ${{ inputs.generate-sbom == 'true' }}
       shell: bash
       run: |
-        # We need to disable the new bundle format enabled by default since 
-        # cosign v3.x.x because some verification tools (e.g. slsactl) are not
-        # able to properly verify the signatures using this new format
-        cosign sign-blob --yes --new-bundle-format=false --use-signing-config=false \
+        cosign sign-blob --yes \
           --output-certificate policy-sbom.spdx.cert \
           --output-signature policy-sbom.spdx.sig \
           policy-sbom.spdx.json
+
     - name: Upload policy SBOM files
       if: ${{ inputs.generate-sbom == 'true' }}
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0

--- a/policy-build-tinygo/action.yml
+++ b/policy-build-tinygo/action.yml
@@ -49,17 +49,16 @@ runs:
       shell: bash
       run: |
         make annotated-policy.wasm
+
     - name: Sign BOM file
       if: ${{ inputs.generate-sbom == 'true' }}
       shell: bash
       run: |
-        # We need to disable the new bundle format enabled by default since 
-        # cosign v3.x.x because some verification tools (e.g. slsactl) are not
-        # able to properly verify the signatures using this new format
-        cosign sign-blob --yes --new-bundle-format=false --use-signing-config=false \
+        cosign sign-blob --yes \
           --output-certificate policy-sbom.spdx.cert \
           --output-signature policy-sbom.spdx.sig \
           policy-sbom.spdx.json
+
     - name: Upload policy SBOM files
       if: ${{ inputs.generate-sbom == 'true' }}
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0

--- a/policy-release/action.yml
+++ b/policy-release/action.yml
@@ -46,10 +46,14 @@ runs:
         IMMUTABLE_REF=$(kwctl push -o json ${{ inputs.annotated-wasm }} ${{ inputs.oci-target }}:latest | jq -r .immutable_ref)
 
         echo Keyless signing of policy using cosign
+
         # We need to disable the new bundle format enabled by default since 
         # cosign v3.x.x because some verification tools (e.g. slsactl) are not
         # able to properly verify the signatures using this new format
         cosign sign --yes --new-bundle-format=false --use-signing-config=false ${IMMUTABLE_REF}
+
+        # Sign also with cosign v3 signature format
+        cosign sign --yes --new-bundle-format=true --use-signing-config=true ${IMMUTABLE_REF}
     - name: Publish Wasm policy artifact to OCI registry with the version tag and 'latest'
       shell: bash
       if: ${{ ! startsWith(github.ref, 'refs/heads/') }}
@@ -62,10 +66,14 @@ runs:
         IMMUTABLE_REF=$(kwctl push -o json ${{ inputs.annotated-wasm }} ${{ inputs.oci-target }}:${OCI_TAG} | jq -r .immutable_ref)
 
         echo Keyless signing of policy using cosign
+
         # We need to disable the new bundle format enabled by default since 
         # cosign v3.x.x because some verification tools (e.g. slsactl) are not
         # able to properly verify the signatures using this new format
         cosign sign --yes --new-bundle-format=false --use-signing-config=false ${IMMUTABLE_REF}
+
+        # Sign also with cosign v3 signature format
+        cosign sign --yes --new-bundle-format=true --use-signing-config=true ${IMMUTABLE_REF}
     - name: Create release
       if: ${{ ! startsWith(github.ref, 'refs/heads/')  && inputs.policy-working-dir != '.' }}
       # if we are on a monorepo, we create a GH release directly and don't reuse a draft release


### PR DESCRIPTION
## Description

In order to allow old cosign version and other verification tools to verify the signature it's necessary to add a second signature using the old format. The default format before cosign v3 changed the default signature bundle.

Updates the CI to sign the blobs using only cosign v3 signature bundle format.

