### PR TITLE
chore: prepare v4.5.13 release.

### DIFF
--- a/.github/workflows/reusable-release-policy-assemblyscript.yml
+++ b/.github/workflows/reusable-release-policy-assemblyscript.yml
@@ -19,7 +19,7 @@ jobs:
       NODE_VERSION: 14
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.5.12
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.5.13
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -48,7 +48,7 @@ jobs:
       - name: Check that `io.kubewarden.policy.version` annotation is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: kubewarden/github-actions/check-policy-version@v4.5.12
+        uses: kubewarden/github-actions/check-policy-version@v4.5.13
         with:
           expected-version: ${{ steps.calculate-version.outputs.version }}
       - name: Setup node
@@ -71,7 +71,7 @@ jobs:
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@v4.5.12
+        uses: kubewarden/github-actions/policy-release@v4.5.13
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -88,4 +88,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v4.5.12
+        uses: kubewarden/github-actions/push-artifacthub@v4.5.13

--- a/.github/workflows/reusable-release-policy-go-wasi.yml
+++ b/.github/workflows/reusable-release-policy-go-wasi.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.5.12
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.5.13
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -46,16 +46,16 @@ jobs:
       - name: Check that `io.kubewarden.policy.version` annotation is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: kubewarden/github-actions/check-policy-version@v4.5.12
+        uses: kubewarden/github-actions/check-policy-version@v4.5.13
         with:
           expected-version: ${{ steps.calculate-version.outputs.version }}
       - name: Build and annotate policy
-        uses: kubewarden/github-actions/policy-build-go-wasi@v4.5.12
+        uses: kubewarden/github-actions/policy-build-go-wasi@v4.5.13
       - name: Run e2e tests
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@v4.5.12
+        uses: kubewarden/github-actions/policy-release@v4.5.13
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -71,4 +71,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v4.5.12
+        uses: kubewarden/github-actions/push-artifacthub@v4.5.13

--- a/.github/workflows/reusable-release-policy-go.yml
+++ b/.github/workflows/reusable-release-policy-go.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.5.12
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.5.13
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -46,16 +46,16 @@ jobs:
       - name: Check that `io.kubewarden.policy.version` annotation is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: kubewarden/github-actions/check-policy-version@v4.5.12
+        uses: kubewarden/github-actions/check-policy-version@v4.5.13
         with:
           expected-version: ${{ steps.calculate-version.outputs.version }}
       - name: Build and annotate policy
-        uses: kubewarden/github-actions/policy-build-tinygo@v4.5.12
+        uses: kubewarden/github-actions/policy-build-tinygo@v4.5.13
       - name: Run e2e tests
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@v4.5.12
+        uses: kubewarden/github-actions/policy-release@v4.5.13
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -71,4 +71,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v4.5.12
+        uses: kubewarden/github-actions/push-artifacthub@v4.5.13

--- a/.github/workflows/reusable-release-policy-rego.yml
+++ b/.github/workflows/reusable-release-policy-rego.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.5.12
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.5.13
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -64,12 +64,12 @@ jobs:
       - name: Check that `io.kubewarden.policy.version` annotation is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: kubewarden/github-actions/check-policy-version@v4.5.12
+        uses: kubewarden/github-actions/check-policy-version@v4.5.13
         with:
           expected-version: ${{ steps.calculate-version.outputs.version }}
           policy-working-dir: ${{ inputs.policy-working-dir }}
       - name: Install opa
-        uses: kubewarden/github-actions/opa-installer@v4.5.12
+        uses: kubewarden/github-actions/opa-installer@v4.5.13
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Build policy
         working-directory: ${{ inputs.policy-working-dir }}
@@ -87,7 +87,7 @@ jobs:
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@v4.5.12
+        uses: kubewarden/github-actions/policy-release@v4.5.13
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -105,6 +105,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v4.5.12
+        uses: kubewarden/github-actions/push-artifacthub@v4.5.13
         with:
           policy-working-dir: ${{ inputs.policy-working-dir }}

--- a/.github/workflows/reusable-release-policy-rust.yml
+++ b/.github/workflows/reusable-release-policy-rust.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.5.12
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.5.13
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -46,16 +46,16 @@ jobs:
       - name: Check that `io.kubewarden.policy.version` annotation is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: kubewarden/github-actions/check-policy-version@v4.5.12
+        uses: kubewarden/github-actions/check-policy-version@v4.5.13
         with:
           expected-version: ${{ steps.calculate-version.outputs.version }}
       - name: Build and annotate policy
-        uses: kubewarden/github-actions/policy-build-rust@v4.5.12
+        uses: kubewarden/github-actions/policy-build-rust@v4.5.13
       - name: Run e2e tests
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@v4.5.12
+        uses: kubewarden/github-actions/policy-release@v4.5.13
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -71,4 +71,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v4.5.12
+        uses: kubewarden/github-actions/push-artifacthub@v4.5.13

--- a/.github/workflows/reusable-release-policy-swift.yml
+++ b/.github/workflows/reusable-release-policy-swift.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.5.12
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.5.13
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -46,7 +46,7 @@ jobs:
       - name: Check that `io.kubewarden.policy.version` annotation is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: kubewarden/github-actions/check-policy-version@v4.5.12
+        uses: kubewarden/github-actions/check-policy-version@v4.5.13
         with:
           expected-version: ${{ steps.calculate-version.outputs.version }}
       - name: install wasm-strip
@@ -72,7 +72,7 @@ jobs:
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@v4.5.12
+        uses: kubewarden/github-actions/policy-release@v4.5.13
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -88,4 +88,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@v4.5.12
+        uses: kubewarden/github-actions/push-artifacthub@v4.5.13

--- a/.github/workflows/reusable-test-policy-go-wasi.yml
+++ b/.github/workflows/reusable-test-policy-go-wasi.yml
@@ -23,11 +23,11 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.5.12
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.5.13
       - name: Build and annotate policy
         with:
           generate-sbom: false
-        uses: kubewarden/github-actions/policy-build-go-wasi@v4.5.12
+        uses: kubewarden/github-actions/policy-build-go-wasi@v4.5.13
       - name: Run e2e tests
         run: make e2e-tests
 

--- a/.github/workflows/reusable-test-policy-go.yml
+++ b/.github/workflows/reusable-test-policy-go.yml
@@ -23,11 +23,11 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.5.12
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.5.13
       - name: Build and annotate policy
         with:
           generate-sbom: false
-        uses: kubewarden/github-actions/policy-build-tinygo@v4.5.12
+        uses: kubewarden/github-actions/policy-build-tinygo@v4.5.13
       - name: Run e2e tests
         run: make e2e-tests
 

--- a/.github/workflows/reusable-test-policy-rego.yml
+++ b/.github/workflows/reusable-test-policy-rego.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Install opa
-        uses: kubewarden/github-actions/opa-installer@v4.5.12
+        uses: kubewarden/github-actions/opa-installer@v4.5.13
       - name: Run unit tests
         working-directory: ${{ inputs.policy-working-dir }}
         run: make test

--- a/.github/workflows/reusable-test-policy-rust.yml
+++ b/.github/workflows/reusable-test-policy-rust.yml
@@ -53,11 +53,11 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.5.12
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@v4.5.13
       - name: Build and annotate policy
         with:
           generate-sbom: false
-        uses: kubewarden/github-actions/policy-build-rust@v4.5.12
+        uses: kubewarden/github-actions/policy-build-rust@v4.5.13
       - name: Run e2e tests
         run: |
           make e2e-tests

--- a/policy-gh-action-dependencies/action.yml
+++ b/policy-gh-action-dependencies/action.yml
@@ -9,11 +9,11 @@ runs:
     - name: Install cosign
       uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
     - name: Install kwctl
-      uses: kubewarden/github-actions/kwctl-installer@v4.5.12
+      uses: kubewarden/github-actions/kwctl-installer@v4.5.13
     - name: Install bats
       run: sudo apt install -y bats
       shell: bash
     - name: Install SBOM generator tool
-      uses: kubewarden/github-actions/syft-installer@v4.5.12
+      uses: kubewarden/github-actions/syft-installer@v4.5.13
     - name: Install binaryen tool
-      uses: kubewarden/github-actions/binaryen-installer@v4.5.12
+      uses: kubewarden/github-actions/binaryen-installer@v4.5.13

--- a/push-artifacthub/action.yml
+++ b/push-artifacthub/action.yml
@@ -12,7 +12,7 @@ runs:
   using: "composite"
   steps:
     - name: Install kwctl
-      uses: kubewarden/github-actions/kwctl-installer@v4.5.12
+      uses: kubewarden/github-actions/kwctl-installer@v4.5.13
     - name: Checkout code
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:


### PR DESCRIPTION
Prepare for 4.5.13 release, this includes the cosign v2 and v3 fixes.
