### PR TITLE
fix(kwctl-installer): allow "latest" kwctl version

### DIFF
--- a/kwctl-installer/README.md
+++ b/kwctl-installer/README.md
@@ -1,6 +1,6 @@
 # Install kwctl binary
 
-This action downloads latest stable release of kwctl and installs that inside
+This action downloads a release of kwctl and installs that inside
 of the GitHub action path.
 
 The downloaded zip contains both the `kwctl` binary and its
@@ -12,4 +12,8 @@ The downloaded zip contains both the `kwctl` binary and its
 
 ## Inputs
 
-* `KWCTL_VERSION`: (**optional**) the version of kwctl to be downloaded
+* `KWCTL_VERSION`: (**optional**) the version of kwctl to be downloaded.
+  Accepts a specific semver tag (e.g. `v1.34.2`) or the special value
+  `latest`, which resolves to the most recent release in
+  `kubewarden/kubewarden-controller` (including `rc`, `alpha`, and `beta`
+  pre-releases).

--- a/kwctl-installer/action.yml
+++ b/kwctl-installer/action.yml
@@ -14,15 +14,23 @@ runs:
     - uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
 
     - shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
         #!/bin/bash
         set -euo pipefail
 
         KWCTL_VERSION="${{ inputs.kwctl-version }}"
+
+        if [[ "$KWCTL_VERSION" == "latest" ]]; then
+          KWCTL_VERSION=$(gh release list --repo kubewarden/kubewarden-controller --exclude-drafts --limit 1 --json tagName --jq '.[0].tagName')
+          echo "Resolved latest to: $KWCTL_VERSION"
+        fi
+
         SEMVER_PATTERN='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
 
         if [[ ! "$KWCTL_VERSION" =~ $SEMVER_PATTERN ]]; then
-          echo "Invalid kwctl-version: '$KWCTL_VERSION'. Expected format: v<major>.<minor>.<patch> (optional pre-release/build metadata)."
+          echo "Invalid kwctl-version: '$KWCTL_VERSION'. Expected format: v<major>.<minor>.<patch> (optional pre-release/build metadata), or 'latest'."
           exit 1
         fi
 


### PR DESCRIPTION
## Description

Updates the kwctl-installer to allow caller to define "latest" as version to be installed. In this cases, the installer will find the most recent version released version in the kubewarden/kubewarden-controller repository and install it.

Fix the issue reported by @kravciak on this [comment](https://github.com/kubewarden/github-actions/pull/290#issuecomment-4246292298)