### PR TITLE
feat: Enhance script to bump and consume policy-gh-action-dependencies

### DIFF
--- a/.github/workflows/reusable-release-policy-assemblyscript.yml
+++ b/.github/workflows/reusable-release-policy-assemblyscript.yml
@@ -19,7 +19,7 @@ jobs:
       NODE_VERSION: 14
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@5e314eb97966f953c1539dddae57174fa22deb56
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@63e6bff6226bbdd84a4244892417eb27676b7a8c
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -48,7 +48,7 @@ jobs:
       - name: Check that `io.kubewarden.policy.version` annotation is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: kubewarden/github-actions/check-policy-version@5e314eb97966f953c1539dddae57174fa22deb56
+        uses: kubewarden/github-actions/check-policy-version@63e6bff6226bbdd84a4244892417eb27676b7a8c
         with:
           expected-version: ${{ steps.calculate-version.outputs.version }}
       - name: Setup node
@@ -71,7 +71,7 @@ jobs:
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@5e314eb97966f953c1539dddae57174fa22deb56
+        uses: kubewarden/github-actions/policy-release@63e6bff6226bbdd84a4244892417eb27676b7a8c
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -88,4 +88,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@5e314eb97966f953c1539dddae57174fa22deb56
+        uses: kubewarden/github-actions/push-artifacthub@63e6bff6226bbdd84a4244892417eb27676b7a8c

--- a/.github/workflows/reusable-release-policy-go-wasi.yml
+++ b/.github/workflows/reusable-release-policy-go-wasi.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@5e314eb97966f953c1539dddae57174fa22deb56
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@63e6bff6226bbdd84a4244892417eb27676b7a8c
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -46,16 +46,16 @@ jobs:
       - name: Check that `io.kubewarden.policy.version` annotation is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: kubewarden/github-actions/check-policy-version@5e314eb97966f953c1539dddae57174fa22deb56
+        uses: kubewarden/github-actions/check-policy-version@63e6bff6226bbdd84a4244892417eb27676b7a8c
         with:
           expected-version: ${{ steps.calculate-version.outputs.version }}
       - name: Build and annotate policy
-        uses: kubewarden/github-actions/policy-build-go-wasi@5e314eb97966f953c1539dddae57174fa22deb56
+        uses: kubewarden/github-actions/policy-build-go-wasi@63e6bff6226bbdd84a4244892417eb27676b7a8c
       - name: Run e2e tests
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@5e314eb97966f953c1539dddae57174fa22deb56
+        uses: kubewarden/github-actions/policy-release@63e6bff6226bbdd84a4244892417eb27676b7a8c
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -71,4 +71,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@5e314eb97966f953c1539dddae57174fa22deb56
+        uses: kubewarden/github-actions/push-artifacthub@63e6bff6226bbdd84a4244892417eb27676b7a8c

--- a/.github/workflows/reusable-release-policy-go.yml
+++ b/.github/workflows/reusable-release-policy-go.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@5e314eb97966f953c1539dddae57174fa22deb56
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@63e6bff6226bbdd84a4244892417eb27676b7a8c
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -46,16 +46,16 @@ jobs:
       - name: Check that `io.kubewarden.policy.version` annotation is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: kubewarden/github-actions/check-policy-version@5e314eb97966f953c1539dddae57174fa22deb56
+        uses: kubewarden/github-actions/check-policy-version@63e6bff6226bbdd84a4244892417eb27676b7a8c
         with:
           expected-version: ${{ steps.calculate-version.outputs.version }}
       - name: Build and annotate policy
-        uses: kubewarden/github-actions/policy-build-tinygo@5e314eb97966f953c1539dddae57174fa22deb56
+        uses: kubewarden/github-actions/policy-build-tinygo@63e6bff6226bbdd84a4244892417eb27676b7a8c
       - name: Run e2e tests
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@5e314eb97966f953c1539dddae57174fa22deb56
+        uses: kubewarden/github-actions/policy-release@63e6bff6226bbdd84a4244892417eb27676b7a8c
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -71,4 +71,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@5e314eb97966f953c1539dddae57174fa22deb56
+        uses: kubewarden/github-actions/push-artifacthub@63e6bff6226bbdd84a4244892417eb27676b7a8c

--- a/.github/workflows/reusable-release-policy-rego.yml
+++ b/.github/workflows/reusable-release-policy-rego.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@5e314eb97966f953c1539dddae57174fa22deb56
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@63e6bff6226bbdd84a4244892417eb27676b7a8c
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -64,12 +64,12 @@ jobs:
       - name: Check that `io.kubewarden.policy.version` annotation is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: kubewarden/github-actions/check-policy-version@5e314eb97966f953c1539dddae57174fa22deb56
+        uses: kubewarden/github-actions/check-policy-version@63e6bff6226bbdd84a4244892417eb27676b7a8c
         with:
           expected-version: ${{ steps.calculate-version.outputs.version }}
           policy-working-dir: ${{ inputs.policy-working-dir }}
       - name: Install opa
-        uses: kubewarden/github-actions/opa-installer@5e314eb97966f953c1539dddae57174fa22deb56
+        uses: kubewarden/github-actions/opa-installer@63e6bff6226bbdd84a4244892417eb27676b7a8c
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Build policy
         working-directory: ${{ inputs.policy-working-dir }}
@@ -87,7 +87,7 @@ jobs:
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@5e314eb97966f953c1539dddae57174fa22deb56
+        uses: kubewarden/github-actions/policy-release@63e6bff6226bbdd84a4244892417eb27676b7a8c
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -105,6 +105,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@5e314eb97966f953c1539dddae57174fa22deb56
+        uses: kubewarden/github-actions/push-artifacthub@63e6bff6226bbdd84a4244892417eb27676b7a8c
         with:
           policy-working-dir: ${{ inputs.policy-working-dir }}

--- a/.github/workflows/reusable-release-policy-rust.yml
+++ b/.github/workflows/reusable-release-policy-rust.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@5e314eb97966f953c1539dddae57174fa22deb56
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@63e6bff6226bbdd84a4244892417eb27676b7a8c
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -46,16 +46,16 @@ jobs:
       - name: Check that `io.kubewarden.policy.version` annotation is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: kubewarden/github-actions/check-policy-version@5e314eb97966f953c1539dddae57174fa22deb56
+        uses: kubewarden/github-actions/check-policy-version@63e6bff6226bbdd84a4244892417eb27676b7a8c
         with:
           expected-version: ${{ steps.calculate-version.outputs.version }}
       - name: Build and annotate policy
-        uses: kubewarden/github-actions/policy-build-rust@5e314eb97966f953c1539dddae57174fa22deb56
+        uses: kubewarden/github-actions/policy-build-rust@63e6bff6226bbdd84a4244892417eb27676b7a8c
       - name: Run e2e tests
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@5e314eb97966f953c1539dddae57174fa22deb56
+        uses: kubewarden/github-actions/policy-release@63e6bff6226bbdd84a4244892417eb27676b7a8c
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -71,4 +71,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@5e314eb97966f953c1539dddae57174fa22deb56
+        uses: kubewarden/github-actions/push-artifacthub@63e6bff6226bbdd84a4244892417eb27676b7a8c

--- a/.github/workflows/reusable-release-policy-swift.yml
+++ b/.github/workflows/reusable-release-policy-swift.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@5e314eb97966f953c1539dddae57174fa22deb56
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@63e6bff6226bbdd84a4244892417eb27676b7a8c
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -46,7 +46,7 @@ jobs:
       - name: Check that `io.kubewarden.policy.version` annotation is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: kubewarden/github-actions/check-policy-version@5e314eb97966f953c1539dddae57174fa22deb56
+        uses: kubewarden/github-actions/check-policy-version@63e6bff6226bbdd84a4244892417eb27676b7a8c
         with:
           expected-version: ${{ steps.calculate-version.outputs.version }}
       - name: install wasm-strip
@@ -72,7 +72,7 @@ jobs:
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@5e314eb97966f953c1539dddae57174fa22deb56
+        uses: kubewarden/github-actions/policy-release@63e6bff6226bbdd84a4244892417eb27676b7a8c
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -88,4 +88,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@5e314eb97966f953c1539dddae57174fa22deb56
+        uses: kubewarden/github-actions/push-artifacthub@63e6bff6226bbdd84a4244892417eb27676b7a8c

--- a/.github/workflows/reusable-test-policy-go-wasi.yml
+++ b/.github/workflows/reusable-test-policy-go-wasi.yml
@@ -23,11 +23,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@5e314eb97966f953c1539dddae57174fa22deb56
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@63e6bff6226bbdd84a4244892417eb27676b7a8c
       - name: Build and annotate policy
         with:
           generate-sbom: false
-        uses: kubewarden/github-actions/policy-build-go-wasi@5e314eb97966f953c1539dddae57174fa22deb56
+        uses: kubewarden/github-actions/policy-build-go-wasi@63e6bff6226bbdd84a4244892417eb27676b7a8c
       - name: Run e2e tests
         run: make e2e-tests
 

--- a/.github/workflows/reusable-test-policy-go.yml
+++ b/.github/workflows/reusable-test-policy-go.yml
@@ -23,11 +23,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@5e314eb97966f953c1539dddae57174fa22deb56
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@63e6bff6226bbdd84a4244892417eb27676b7a8c
       - name: Build and annotate policy
         with:
           generate-sbom: false
-        uses: kubewarden/github-actions/policy-build-tinygo@5e314eb97966f953c1539dddae57174fa22deb56
+        uses: kubewarden/github-actions/policy-build-tinygo@63e6bff6226bbdd84a4244892417eb27676b7a8c
       - name: Run e2e tests
         run: make e2e-tests
 

--- a/.github/workflows/reusable-test-policy-rego.yml
+++ b/.github/workflows/reusable-test-policy-rego.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install opa
-        uses: kubewarden/github-actions/opa-installer@5e314eb97966f953c1539dddae57174fa22deb56
+        uses: kubewarden/github-actions/opa-installer@63e6bff6226bbdd84a4244892417eb27676b7a8c
       - name: Run unit tests
         working-directory: ${{ inputs.policy-working-dir }}
         run: make test

--- a/.github/workflows/reusable-test-policy-rust.yml
+++ b/.github/workflows/reusable-test-policy-rust.yml
@@ -53,11 +53,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@5e314eb97966f953c1539dddae57174fa22deb56
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@63e6bff6226bbdd84a4244892417eb27676b7a8c
       - name: Build and annotate policy
         with:
           generate-sbom: false
-        uses: kubewarden/github-actions/policy-build-rust@5e314eb97966f953c1539dddae57174fa22deb56
+        uses: kubewarden/github-actions/policy-build-rust@63e6bff6226bbdd84a4244892417eb27676b7a8c
       - name: Run e2e tests
         run: |
           make e2e-tests

--- a/attestation/action.yml
+++ b/attestation/action.yml
@@ -18,7 +18,7 @@ runs:
     - name: Install cosign
       uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
     - name: Install the crane command
-      uses: kubewarden/github-actions/crane-installer@5e314eb97966f953c1539dddae57174fa22deb56
+      uses: kubewarden/github-actions/crane-installer@63e6bff6226bbdd84a4244892417eb27676b7a8c
     - name: Login to GitHub Container Registry
       uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
       with:

--- a/policy-gh-action-dependencies/action.yml
+++ b/policy-gh-action-dependencies/action.yml
@@ -9,11 +9,11 @@ runs:
     - name: Install cosign
       uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
     - name: Install kwctl
-      uses: kubewarden/github-actions/kwctl-installer@5e314eb97966f953c1539dddae57174fa22deb56
+      uses: kubewarden/github-actions/kwctl-installer@63e6bff6226bbdd84a4244892417eb27676b7a8c
     - name: Install bats
       run: sudo apt install -y bats
       shell: bash
     - name: Install SBOM generator tool
-      uses: kubewarden/github-actions/syft-installer@5e314eb97966f953c1539dddae57174fa22deb56
+      uses: kubewarden/github-actions/syft-installer@63e6bff6226bbdd84a4244892417eb27676b7a8c
     - name: Install binaryen tool
-      uses: kubewarden/github-actions/binaryen-installer@5e314eb97966f953c1539dddae57174fa22deb56
+      uses: kubewarden/github-actions/binaryen-installer@63e6bff6226bbdd84a4244892417eb27676b7a8c

--- a/push-artifacthub/action.yml
+++ b/push-artifacthub/action.yml
@@ -12,7 +12,7 @@ runs:
   using: "composite"
   steps:
     - name: Install kwctl
-      uses: kubewarden/github-actions/kwctl-installer@5e314eb97966f953c1539dddae57174fa22deb56
+      uses: kubewarden/github-actions/kwctl-installer@63e6bff6226bbdd84a4244892417eb27676b7a8c
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:

--- a/scripts/update-kubewarden-refs.sh
+++ b/scripts/update-kubewarden-refs.sh
@@ -5,11 +5,23 @@
 # with a given commit SHA. Run this before tagging a new release so that
 # self-referential workflow steps point to the commit with the desired version.
 #
-# Usage:
-#   scripts/update-kubewarden-refs.sh [<commit-sha>]
+# This covers every file that references kubewarden/github-actions — including
+# policy-gh-action-dependencies/action.yml (which pins kwctl-installer,
+# syft-installer, and binaryen-installer) and all workflow files that consume
+# policy-gh-action-dependencies — because all of them use the same
+# kubewarden/github-actions/<sub-action>@<sha> pattern.
 #
-#   <commit-sha>  Full 40-character hex SHA to pin to.
-#                 Defaults to the current HEAD of the repository.
+# Optionally, third-party sigstore/cosign-installer pins can be updated at the
+# same time with --cosign-version (requires the gh CLI).
+#
+# Usage:
+#   scripts/update-kubewarden-refs.sh [--cosign-version <tag>] [<commit-sha>]
+#
+#   --cosign-version <tag>  Update every sigstore/cosign-installer pin to this
+#                           tag (e.g. v4.2.0). Fetches the commit SHA via the
+#                           GitHub API; requires gh CLI to be installed.
+#   <commit-sha>            Full 40-character hex SHA to pin to.
+#                           Defaults to the current HEAD of the repository.
 
 set -euo pipefail
 
@@ -18,9 +30,11 @@ set -euo pipefail
 # ---------------------------------------------------------------------------
 
 usage() {
-    echo "Usage: $(basename "$0") [<commit-sha>]"
+    echo "Usage: $(basename "$0") [--cosign-version <tag>] [<commit-sha>]"
     echo ""
-    echo "  <commit-sha>  40-char hex SHA to pin to (default: HEAD)"
+    echo "  --cosign-version <tag>  Update sigstore/cosign-installer pins to this"
+    echo "                          tag (e.g. v4.2.0). Requires gh CLI."
+    echo "  <commit-sha>            40-char hex SHA to pin to (default: HEAD)"
     exit 1
 }
 
@@ -33,31 +47,73 @@ is_valid_sha() {
     [[ "$1" =~ ^[0-9a-fA-F]{40}$ ]]
 }
 
+is_valid_tag() {
+    # Accept typical semver-style git tags: v1.2.3, v1.2.3-rc1, etc.
+    [[ "$1" =~ ^v[0-9]+\.[0-9]+(\.[0-9]+)?([._-][a-zA-Z0-9._-]+)*$ ]]
+}
+
 # ---------------------------------------------------------------------------
 # Argument parsing
 # ---------------------------------------------------------------------------
 
-if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
-    usage
-fi
+COSIGN_VERSION=""
+NEW_SHA=""
 
-if [[ $# -gt 1 ]]; then
-    die "Too many arguments. Expected at most one SHA argument."
-fi
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h|--help)
+            usage
+            ;;
+        --cosign-version)
+            [[ $# -ge 2 ]] || die "--cosign-version requires a tag argument."
+            COSIGN_VERSION="$2"
+            shift 2
+            ;;
+        -*)
+            die "Unknown option: '$1'"
+            ;;
+        *)
+            [[ -z "$NEW_SHA" ]] || die "Too many arguments. Expected at most one SHA argument."
+            NEW_SHA="$1"
+            shift
+            ;;
+    esac
+done
 
 # Resolve repository root so the script works from any working directory.
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) \
     || die "Not inside a git repository."
 
-if [[ $# -eq 1 ]]; then
-    NEW_SHA="$1"
-else
+if [[ -z "$NEW_SHA" ]]; then
     NEW_SHA=$(git -C "$REPO_ROOT" rev-parse HEAD) \
         || die "Failed to resolve HEAD commit SHA."
 fi
 
 is_valid_sha "$NEW_SHA" \
     || die "Invalid SHA: '$NEW_SHA'. Must be a 40-character hexadecimal string."
+
+# ---------------------------------------------------------------------------
+# Resolve cosign SHA if requested
+# ---------------------------------------------------------------------------
+
+COSIGN_SHA=""
+
+if [[ -n "$COSIGN_VERSION" ]]; then
+    is_valid_tag "$COSIGN_VERSION" \
+        || die "Invalid cosign tag: '$COSIGN_VERSION'. Expected format: v1.2.3"
+
+    command -v gh >/dev/null 2>&1 \
+        || die "gh CLI not found. Install it or omit --cosign-version."
+
+    echo "Fetching commit SHA for sigstore/cosign-installer@${COSIGN_VERSION}..."
+    COSIGN_SHA=$(gh api "repos/sigstore/cosign-installer/commits/${COSIGN_VERSION}" --jq '.sha' 2>/dev/null) \
+        || die "Failed to fetch SHA for sigstore/cosign-installer@${COSIGN_VERSION}. Check the tag name and gh authentication."
+
+    is_valid_sha "$COSIGN_SHA" \
+        || die "Unexpected response from GitHub API (not a valid SHA): '$COSIGN_SHA'"
+
+    echo "  cosign-installer ${COSIGN_VERSION} → ${COSIGN_SHA}"
+fi
 
 # ---------------------------------------------------------------------------
 # Find YAML files
@@ -77,31 +133,52 @@ fi
 # ---------------------------------------------------------------------------
 # Replace SHA references
 #
-# Target pattern (with or without a trailing comment):
+# Kubewarden target pattern (with or without a trailing comment):
 #   uses: kubewarden/github-actions/<sub-action>@<40-char-sha>[ # anything]
 #
 # Replacement (no trailing comment):
 #   uses: kubewarden/github-actions/<sub-action>@<NEW_SHA>
+#
+# Cosign target pattern (trailing comment replaced with new version tag):
+#   uses: sigstore/cosign-installer@<40-char-sha>[ # anything]
+#
+# Replacement:
+#   uses: sigstore/cosign-installer@<COSIGN_SHA> # <COSIGN_VERSION>
 # ---------------------------------------------------------------------------
 
-CHANGED=0
+KW_CHANGED=0
+COSIGN_CHANGED=0
+COSIGN_SKIPPED=0
 
 for FILE in "${YAML_FILES[@]}"; do
-    # Check if the file has any kubewarden/github-actions reference at all.
-    if ! grep -qE 'uses:[[:space:]]+kubewarden/github-actions/[^@]+@[0-9a-fA-F]{40}' "$FILE" 2>/dev/null; then
-        continue
+    HAS_KW=false
+    HAS_COSIGN=false
+
+    grep -qE 'uses:[[:space:]]+kubewarden/github-actions/[^@]+@[0-9a-fA-F]{40}' "$FILE" 2>/dev/null \
+        && HAS_KW=true
+    grep -qE 'uses:[[:space:]]+sigstore/cosign-installer@[0-9a-fA-F]{40}' "$FILE" 2>/dev/null \
+        && HAS_COSIGN=true
+
+    [[ "$HAS_KW" == true || "$HAS_COSIGN" == true ]] || continue
+
+    if [[ "$HAS_KW" == true ]]; then
+        sed -i -E \
+            's|(uses:[[:space:]]+kubewarden/github-actions/[^@]+@)[0-9a-fA-F]{40}([[:space:]]*#[^\n]*)?\s*$|\1'"$NEW_SHA"'|g' \
+            "$FILE" || die "sed failed on file: $FILE"
+        echo "Updated (kubewarden refs):   $FILE"
+        KW_CHANGED=$((KW_CHANGED + 1))
     fi
 
-    # Perform the in-place substitution:
-    #   - Match the SHA (40 hex chars) after the @ in a kubewarden ref
-    #   - Remove any trailing " # ..." comment on the same line
-    if sed -i -E \
-        's|(uses:[[:space:]]+kubewarden/github-actions/[^@]+@)[0-9a-fA-F]{40}([[:space:]]*#[^\n]*)?\s*$|\1'"$NEW_SHA"'|g' \
-        "$FILE"; then
-        echo "Updated: $FILE"
-        CHANGED=$((CHANGED + 1))
-    else
-        die "sed failed on file: $FILE"
+    if [[ "$HAS_COSIGN" == true ]]; then
+        if [[ -n "$COSIGN_SHA" ]]; then
+            sed -i -E \
+                's|(uses:[[:space:]]+sigstore/cosign-installer@)[0-9a-fA-F]{40}([[:space:]]*#[^\n]*)?\s*$|\1'"$COSIGN_SHA"' # '"$COSIGN_VERSION"'|g' \
+                "$FILE" || die "sed failed on file: $FILE"
+            echo "Updated (cosign-installer):  $FILE"
+            COSIGN_CHANGED=$((COSIGN_CHANGED + 1))
+        else
+            COSIGN_SKIPPED=$((COSIGN_SKIPPED + 1))
+        fi
     fi
 done
 
@@ -109,9 +186,19 @@ done
 # Summary
 # ---------------------------------------------------------------------------
 
-if [[ $CHANGED -eq 0 ]]; then
+echo ""
+
+if [[ $KW_CHANGED -eq 0 ]]; then
     echo "No kubewarden/github-actions SHA references found — nothing to update."
 else
-    echo ""
-    echo "Done. Updated $CHANGED file(s) to SHA $NEW_SHA"
+    echo "Done. Updated $KW_CHANGED file(s) to kubewarden SHA $NEW_SHA"
+fi
+
+if [[ $COSIGN_CHANGED -gt 0 ]]; then
+    echo "Done. Updated $COSIGN_CHANGED file(s) to cosign-installer ${COSIGN_VERSION} (${COSIGN_SHA})"
+fi
+
+if [[ $COSIGN_SKIPPED -gt 0 ]]; then
+    echo "Skipped $COSIGN_SKIPPED file(s) with sigstore/cosign-installer pins."
+    echo "  Re-run with --cosign-version <tag> to update them (e.g. --cosign-version v4.1.1)."
 fi


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->

Enhance script to also bump and consume `policy-gh-action-dependencies`, and then consume it in our reusable workflows.

Bump shasums for future v5.0.2.

This will fix [go-wasi-policy-template](https://github.com/kubewarden/go-wasi-policy-template/actions/runs/24595468734/job/71924477623) and others.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

CI

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

## Checklist

- [ ] I have read and understood the [Kubewarden AI Policy](https://github.com/kubewarden/community/blob/main/AI_POLICY.md)
