### PR TITLE
Add --locked to Rust cargo commands

### DIFF
--- a/.github/workflows/reusable-test-policy-rust.yml
+++ b/.github/workflows/reusable-test-policy-rust.yml
@@ -31,7 +31,7 @@ jobs:
           rustup override set stable
         shell: bash
       - name: Run Cargo check
-        run: cargo check --workspace
+        run: cargo check --workspace --locked
         shell: bash
 
   test:
@@ -45,7 +45,7 @@ jobs:
           rustup override set stable
         shell: bash
       - name: Run Cargo test
-        run: cargo test --workspace
+        run: cargo test --workspace --locked
         shell: bash
   e2e-tests:
     name: E2E testSuite
@@ -85,4 +85,4 @@ jobs:
           rustup toolchain install stable  --profile minimal --target wasm32-wasip1 --component clippy
           rustup override set stable
       - name: Run Cargo clippy
-        run: cargo clippy --workspace -- -D warnings
+        run: cargo clippy --workspace --locked -- -D warnings

--- a/policy-build-rust/action.yml
+++ b/policy-build-rust/action.yml
@@ -22,7 +22,7 @@ runs:
         rustup override set stable
     - name: Build Wasm module
       shell: bash
-      run: cargo build --target=wasm32-wasip1 --release
+      run: cargo build --target=wasm32-wasip1 --release --locked
     - name: Rename Wasm module
       shell: bash
       run: |


### PR DESCRIPTION
## Description

Fixes #234.

- Add --locked to the Rust policy reusable workflow cargo check, cargo test, and cargo clippy commands.
- Add --locked to the Rust policy build composite action cargo build command, since it is used by the reusable Rust policy workflow.

## Test

- git diff --check
- yq e . .github/workflows/reusable-test-policy-rust.yml policy-build-rust/action.yml
- rg --hidden --pcre2 check for cargo build/test/check/clippy commands without --locked; no matches