### PR TITLE
Ship annotated wasm in policy releases

### DIFF
--- a/policy-release/action.yml
+++ b/policy-release/action.yml
@@ -74,6 +74,13 @@ runs:
 
         # Sign also with cosign v3 signature format
         cosign sign --yes --new-bundle-format=true --use-signing-config=true ${IMMUTABLE_REF}
+    - name: Prepare policy.wasm release asset
+      if: ${{ ! startsWith(github.ref, 'refs/heads/') }}
+      shell: bash
+      working-directory: ${{ inputs.policy-working-dir }}
+      run: |
+        set -euo pipefail
+        cp "${{ inputs.annotated-wasm }}" "$RUNNER_TEMP/policy.wasm"
     - name: Create release
       if: ${{ ! startsWith(github.ref, 'refs/heads/')  && inputs.policy-working-dir != '.' }}
       # if we are on a monorepo, we create a GH release directly and don't reuse a draft release
@@ -86,7 +93,7 @@ runs:
         draft: false
         prerelease: ${{ contains(inputs.policy-version, '-alpha') || contains(inputs.policy-version, '-beta') || contains(inputs.policy-version, '-rc') }}
         files: |
-          ${{ inputs.policy-working-dir }}/policy.wasm
+          ${{ runner.temp }}/policy.wasm
 
     - name: Get release ID from the release created by release drafter
       if: ${{ ! startsWith(github.ref, 'refs/heads/')  && inputs.policy-working-dir == '.' }}
@@ -112,16 +119,13 @@ runs:
       # if we are on a single repo, we obtain the last draft release as it contains the changelog
       # and edit it by adding the artifacts. Then we mark the release as latest
       uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
-      env:
-        POLICY_WORKING_DIR: ${{ inputs.policy-working-dir }}
       with:
         script: |
           let fs = require('fs');
           let path = require('path');
-          let workingDir = process.env.POLICY_WORKING_DIR || '.';
 
           let files = [
-            `${workingDir}/policy.wasm`,
+            `${process.env.RUNNER_TEMP}/policy.wasm`,
           ]
           const {RELEASE_ID} = process.env
 

--- a/policy-release/action.yml
+++ b/policy-release/action.yml
@@ -84,16 +84,67 @@ runs:
     - name: Create release
       if: ${{ ! startsWith(github.ref, 'refs/heads/')  && inputs.policy-working-dir != '.' }}
       # if we are on a monorepo, we create a GH release directly and don't reuse a draft release
-      uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
-      env:
-        GITHUB_TOKEN: ${{ inputs.github-token }}
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
       with:
-        tag_name: ${{ github.ref }}
-        name: ${{ github.ref_name }}
-        draft: false
-        prerelease: ${{ contains(inputs.policy-version, '-alpha') || contains(inputs.policy-version, '-beta') || contains(inputs.policy-version, '-rc') }}
-        files: |
-          ${{ runner.temp }}/policy.wasm
+        github-token: ${{ inputs.github-token }}
+        script: |
+          const fs = require('fs');
+          const path = require('path');
+
+          const tagName = '${{ github.ref_name }}';
+          const isPreRelease = ${{ contains(inputs.policy-version, '-alpha') || contains(inputs.policy-version, '-beta') || contains(inputs.policy-version, '-rc') }};
+          const owner = context.repo.owner;
+          const repo = context.repo.repo;
+
+          let release;
+          try {
+            release = await github.rest.repos.getReleaseByTag({
+              owner,
+              repo,
+              tag: tagName,
+            });
+            release = await github.rest.repos.updateRelease({
+              owner,
+              repo,
+              release_id: release.data.id,
+              name: tagName,
+              draft: false,
+              prerelease: isPreRelease,
+            });
+          } catch (error) {
+            if (error.status !== 404) {
+              throw error;
+            }
+            release = await github.rest.repos.createRelease({
+              owner,
+              repo,
+              tag_name: tagName,
+              name: tagName,
+              draft: false,
+              prerelease: isPreRelease,
+            });
+          }
+
+          const file = `${process.env.RUNNER_TEMP}/policy.wasm`;
+          const fileData = fs.readFileSync(file);
+          const assetName = path.basename(file);
+          const existingAsset = (release.data.assets || []).find((asset) => asset.name === assetName);
+
+          if (existingAsset) {
+            await github.rest.repos.deleteReleaseAsset({
+              owner,
+              repo,
+              asset_id: existingAsset.id,
+            });
+          }
+
+          await github.rest.repos.uploadReleaseAsset({
+            owner,
+            repo,
+            release_id: release.data.id,
+            name: assetName,
+            data: fileData,
+          });
 
     - name: Get release ID from the release created by release drafter
       if: ${{ ! startsWith(github.ref, 'refs/heads/')  && inputs.policy-working-dir == '.' }}


### PR DESCRIPTION
## Description

Use the annotated wasm as the GitHub release asset content while preserving the release asset name `policy.wasm`.

For tag releases, the action now copies the configured `annotated-wasm` file from `policy-working-dir` into `$RUNNER_TEMP/policy.wasm`. Both the monorepo release path and the single-repo draft-release upload path use that prepared asset. OCI publishing already used the annotated wasm and is unchanged.

Fixes #188

## Test

- `yq e . policy-release/action.yml >/dev/null`
- shell simulation of the `Prepare policy.wasm release asset` copy step
- Node syntax check of the edited `Upload policy.wasm asset` GitHub Script snippet
- `git diff --check`

`actionlint` is not installed in my local environment.
