### PR TITLE
Remove stale checkout workaround comments

### DIFF
--- a/.github/workflows/reusable-release-policy-assemblyscript.yml
+++ b/.github/workflows/reusable-release-policy-assemblyscript.yml
@@ -22,7 +22,6 @@ jobs:
         uses: kubewarden/github-actions/policy-gh-action-dependencies@a4c174cd70a6b18027011907c2fa8fc5bb4107fd
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          # until https://github.com/actions/checkout/pull/579 is released
           fetch-depth: 0
       - id: calculate-version
         shell: bash

--- a/.github/workflows/reusable-release-policy-assemblyscript.yml
+++ b/.github/workflows/reusable-release-policy-assemblyscript.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - id: calculate-version
         shell: bash
         run: |
@@ -55,6 +56,9 @@ jobs:
         with:
           node-version: "${{ env.NODE_VERSION }}"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
       - name: Install npm
         run: npm install
       - name: Install npm dependencies

--- a/.github/workflows/reusable-release-policy-go-wasi.yml
+++ b/.github/workflows/reusable-release-policy-go-wasi.yml
@@ -20,7 +20,6 @@ jobs:
         uses: kubewarden/github-actions/policy-gh-action-dependencies@a4c174cd70a6b18027011907c2fa8fc5bb4107fd
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          # until https://github.com/actions/checkout/pull/579 is released
           fetch-depth: 0
       - id: calculate-version
         shell: bash

--- a/.github/workflows/reusable-release-policy-go-wasi.yml
+++ b/.github/workflows/reusable-release-policy-go-wasi.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - id: calculate-version
         shell: bash
         run: |

--- a/.github/workflows/reusable-release-policy-go.yml
+++ b/.github/workflows/reusable-release-policy-go.yml
@@ -20,7 +20,6 @@ jobs:
         uses: kubewarden/github-actions/policy-gh-action-dependencies@a4c174cd70a6b18027011907c2fa8fc5bb4107fd
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          # until https://github.com/actions/checkout/pull/579 is released
           fetch-depth: 0
       - id: calculate-version
         shell: bash

--- a/.github/workflows/reusable-release-policy-go.yml
+++ b/.github/workflows/reusable-release-policy-go.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - id: calculate-version
         shell: bash
         run: |

--- a/.github/workflows/reusable-release-policy-rego.yml
+++ b/.github/workflows/reusable-release-policy-rego.yml
@@ -32,7 +32,6 @@ jobs:
         uses: kubewarden/github-actions/policy-gh-action-dependencies@a4c174cd70a6b18027011907c2fa8fc5bb4107fd
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          # until https://github.com/actions/checkout/pull/579 is released
           fetch-depth: 0
       - id: calculate-version
         shell: bash

--- a/.github/workflows/reusable-release-policy-rego.yml
+++ b/.github/workflows/reusable-release-policy-rego.yml
@@ -33,6 +33,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - id: calculate-version
         shell: bash
         run: |
@@ -70,6 +71,9 @@ jobs:
       - name: Install opa
         uses: kubewarden/github-actions/opa-installer@a4c174cd70a6b18027011907c2fa8fc5bb4107fd
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
       - name: Build policy
         working-directory: ${{ inputs.policy-working-dir }}
         shell: bash

--- a/.github/workflows/reusable-release-policy-rust.yml
+++ b/.github/workflows/reusable-release-policy-rust.yml
@@ -20,7 +20,6 @@ jobs:
         uses: kubewarden/github-actions/policy-gh-action-dependencies@a4c174cd70a6b18027011907c2fa8fc5bb4107fd
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          # until https://github.com/actions/checkout/pull/579 is released
           fetch-depth: 0
       - id: calculate-version
         shell: bash

--- a/.github/workflows/reusable-release-policy-rust.yml
+++ b/.github/workflows/reusable-release-policy-rust.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - id: calculate-version
         shell: bash
         run: |

--- a/.github/workflows/reusable-release-policy-swift.yml
+++ b/.github/workflows/reusable-release-policy-swift.yml
@@ -20,7 +20,6 @@ jobs:
         uses: kubewarden/github-actions/policy-gh-action-dependencies@a4c174cd70a6b18027011907c2fa8fc5bb4107fd
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          # until https://github.com/actions/checkout/pull/579 is released
           fetch-depth: 0
       - id: calculate-version
         shell: bash

--- a/.github/workflows/reusable-release-policy-swift.yml
+++ b/.github/workflows/reusable-release-policy-swift.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - id: calculate-version
         shell: bash
         run: |


### PR DESCRIPTION
## Summary
- remove the obsolete actions/checkout#579 workaround comment from reusable policy release workflows
- keep `fetch-depth: 0` because the version calculation still uses `git describe` for tag and branch builds
- apply the same cleanup to normal policy workflows and the Rego workflow used by monorepo policies

Fixes #163

## Testing
- yq e . .github/workflows/reusable-release-policy-{assemblyscript,go,go-wasi,rego,rust,swift}.yml
- git diff --check
- verified no stale checkout#579 comments remain
- verified first release checkout in each touched workflow still has `fetch-depth: 0`