### PR TITLE
deps: Bump kwctl to 1.35 for go 1.26 support

### DIFF
--- a/kwctl-installer/action.yml
+++ b/kwctl-installer/action.yml
@@ -7,7 +7,7 @@ inputs:
   kwctl-version:
     description: "kwctl release to be installed"
     required: false
-    default: "v1.34.2"
+    default: "v1.35.0"
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->


<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

## Checklist

- [ ] I have read and understood the [Kubewarden AI Policy](https://github.com/kubewarden/community/blob/main/AI_POLICY.md)
