### PR TITLE
deps: Bump GHA sha for new release

### DIFF
--- a/.github/workflows/reusable-release-policy-assemblyscript.yml
+++ b/.github/workflows/reusable-release-policy-assemblyscript.yml
@@ -19,7 +19,7 @@ jobs:
       NODE_VERSION: 14
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@9bb758a49be7721e7862a6ae9c53f64766fc1215
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@fa781ccab6332172628173be64db32a1d0a877e4
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -48,7 +48,7 @@ jobs:
       - name: Check that `io.kubewarden.policy.version` annotation is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: kubewarden/github-actions/check-policy-version@9bb758a49be7721e7862a6ae9c53f64766fc1215
+        uses: kubewarden/github-actions/check-policy-version@fa781ccab6332172628173be64db32a1d0a877e4
         with:
           expected-version: ${{ steps.calculate-version.outputs.version }}
       - name: Setup node
@@ -71,7 +71,7 @@ jobs:
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@9bb758a49be7721e7862a6ae9c53f64766fc1215
+        uses: kubewarden/github-actions/policy-release@fa781ccab6332172628173be64db32a1d0a877e4
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -88,4 +88,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@9bb758a49be7721e7862a6ae9c53f64766fc1215
+        uses: kubewarden/github-actions/push-artifacthub@fa781ccab6332172628173be64db32a1d0a877e4

--- a/.github/workflows/reusable-release-policy-go-wasi.yml
+++ b/.github/workflows/reusable-release-policy-go-wasi.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@9bb758a49be7721e7862a6ae9c53f64766fc1215
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@fa781ccab6332172628173be64db32a1d0a877e4
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -46,16 +46,16 @@ jobs:
       - name: Check that `io.kubewarden.policy.version` annotation is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: kubewarden/github-actions/check-policy-version@9bb758a49be7721e7862a6ae9c53f64766fc1215
+        uses: kubewarden/github-actions/check-policy-version@fa781ccab6332172628173be64db32a1d0a877e4
         with:
           expected-version: ${{ steps.calculate-version.outputs.version }}
       - name: Build and annotate policy
-        uses: kubewarden/github-actions/policy-build-go-wasi@9bb758a49be7721e7862a6ae9c53f64766fc1215
+        uses: kubewarden/github-actions/policy-build-go-wasi@fa781ccab6332172628173be64db32a1d0a877e4
       - name: Run e2e tests
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@9bb758a49be7721e7862a6ae9c53f64766fc1215
+        uses: kubewarden/github-actions/policy-release@fa781ccab6332172628173be64db32a1d0a877e4
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -71,4 +71,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@9bb758a49be7721e7862a6ae9c53f64766fc1215
+        uses: kubewarden/github-actions/push-artifacthub@fa781ccab6332172628173be64db32a1d0a877e4

--- a/.github/workflows/reusable-release-policy-go.yml
+++ b/.github/workflows/reusable-release-policy-go.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@9bb758a49be7721e7862a6ae9c53f64766fc1215
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@fa781ccab6332172628173be64db32a1d0a877e4
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -46,16 +46,16 @@ jobs:
       - name: Check that `io.kubewarden.policy.version` annotation is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: kubewarden/github-actions/check-policy-version@9bb758a49be7721e7862a6ae9c53f64766fc1215
+        uses: kubewarden/github-actions/check-policy-version@fa781ccab6332172628173be64db32a1d0a877e4
         with:
           expected-version: ${{ steps.calculate-version.outputs.version }}
       - name: Build and annotate policy
-        uses: kubewarden/github-actions/policy-build-tinygo@9bb758a49be7721e7862a6ae9c53f64766fc1215
+        uses: kubewarden/github-actions/policy-build-tinygo@fa781ccab6332172628173be64db32a1d0a877e4
       - name: Run e2e tests
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@9bb758a49be7721e7862a6ae9c53f64766fc1215
+        uses: kubewarden/github-actions/policy-release@fa781ccab6332172628173be64db32a1d0a877e4
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -71,4 +71,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@9bb758a49be7721e7862a6ae9c53f64766fc1215
+        uses: kubewarden/github-actions/push-artifacthub@fa781ccab6332172628173be64db32a1d0a877e4

--- a/.github/workflows/reusable-release-policy-rego.yml
+++ b/.github/workflows/reusable-release-policy-rego.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@9bb758a49be7721e7862a6ae9c53f64766fc1215
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@fa781ccab6332172628173be64db32a1d0a877e4
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -64,12 +64,12 @@ jobs:
       - name: Check that `io.kubewarden.policy.version` annotation is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: kubewarden/github-actions/check-policy-version@9bb758a49be7721e7862a6ae9c53f64766fc1215
+        uses: kubewarden/github-actions/check-policy-version@fa781ccab6332172628173be64db32a1d0a877e4
         with:
           expected-version: ${{ steps.calculate-version.outputs.version }}
           policy-working-dir: ${{ inputs.policy-working-dir }}
       - name: Install opa
-        uses: kubewarden/github-actions/opa-installer@9bb758a49be7721e7862a6ae9c53f64766fc1215
+        uses: kubewarden/github-actions/opa-installer@fa781ccab6332172628173be64db32a1d0a877e4
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Build policy
         working-directory: ${{ inputs.policy-working-dir }}
@@ -87,7 +87,7 @@ jobs:
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@9bb758a49be7721e7862a6ae9c53f64766fc1215
+        uses: kubewarden/github-actions/policy-release@fa781ccab6332172628173be64db32a1d0a877e4
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -105,6 +105,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@9bb758a49be7721e7862a6ae9c53f64766fc1215
+        uses: kubewarden/github-actions/push-artifacthub@fa781ccab6332172628173be64db32a1d0a877e4
         with:
           policy-working-dir: ${{ inputs.policy-working-dir }}

--- a/.github/workflows/reusable-release-policy-rust.yml
+++ b/.github/workflows/reusable-release-policy-rust.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@9bb758a49be7721e7862a6ae9c53f64766fc1215
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@fa781ccab6332172628173be64db32a1d0a877e4
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -46,16 +46,16 @@ jobs:
       - name: Check that `io.kubewarden.policy.version` annotation is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: kubewarden/github-actions/check-policy-version@9bb758a49be7721e7862a6ae9c53f64766fc1215
+        uses: kubewarden/github-actions/check-policy-version@fa781ccab6332172628173be64db32a1d0a877e4
         with:
           expected-version: ${{ steps.calculate-version.outputs.version }}
       - name: Build and annotate policy
-        uses: kubewarden/github-actions/policy-build-rust@9bb758a49be7721e7862a6ae9c53f64766fc1215
+        uses: kubewarden/github-actions/policy-build-rust@fa781ccab6332172628173be64db32a1d0a877e4
       - name: Run e2e tests
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@9bb758a49be7721e7862a6ae9c53f64766fc1215
+        uses: kubewarden/github-actions/policy-release@fa781ccab6332172628173be64db32a1d0a877e4
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -71,4 +71,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@9bb758a49be7721e7862a6ae9c53f64766fc1215
+        uses: kubewarden/github-actions/push-artifacthub@fa781ccab6332172628173be64db32a1d0a877e4

--- a/.github/workflows/reusable-release-policy-swift.yml
+++ b/.github/workflows/reusable-release-policy-swift.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@9bb758a49be7721e7862a6ae9c53f64766fc1215
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@fa781ccab6332172628173be64db32a1d0a877e4
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -46,7 +46,7 @@ jobs:
       - name: Check that `io.kubewarden.policy.version` annotation is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: kubewarden/github-actions/check-policy-version@9bb758a49be7721e7862a6ae9c53f64766fc1215
+        uses: kubewarden/github-actions/check-policy-version@fa781ccab6332172628173be64db32a1d0a877e4
         with:
           expected-version: ${{ steps.calculate-version.outputs.version }}
       - name: install wasm-strip
@@ -72,7 +72,7 @@ jobs:
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@9bb758a49be7721e7862a6ae9c53f64766fc1215
+        uses: kubewarden/github-actions/policy-release@fa781ccab6332172628173be64db32a1d0a877e4
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -88,4 +88,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@9bb758a49be7721e7862a6ae9c53f64766fc1215
+        uses: kubewarden/github-actions/push-artifacthub@fa781ccab6332172628173be64db32a1d0a877e4

--- a/.github/workflows/reusable-test-policy-go-wasi.yml
+++ b/.github/workflows/reusable-test-policy-go-wasi.yml
@@ -23,11 +23,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@9bb758a49be7721e7862a6ae9c53f64766fc1215
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@fa781ccab6332172628173be64db32a1d0a877e4
       - name: Build and annotate policy
         with:
           generate-sbom: false
-        uses: kubewarden/github-actions/policy-build-go-wasi@9bb758a49be7721e7862a6ae9c53f64766fc1215
+        uses: kubewarden/github-actions/policy-build-go-wasi@fa781ccab6332172628173be64db32a1d0a877e4
       - name: Run e2e tests
         run: make e2e-tests
 

--- a/.github/workflows/reusable-test-policy-go.yml
+++ b/.github/workflows/reusable-test-policy-go.yml
@@ -23,11 +23,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@9bb758a49be7721e7862a6ae9c53f64766fc1215
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@fa781ccab6332172628173be64db32a1d0a877e4
       - name: Build and annotate policy
         with:
           generate-sbom: false
-        uses: kubewarden/github-actions/policy-build-tinygo@9bb758a49be7721e7862a6ae9c53f64766fc1215
+        uses: kubewarden/github-actions/policy-build-tinygo@fa781ccab6332172628173be64db32a1d0a877e4
       - name: Run e2e tests
         run: make e2e-tests
 

--- a/.github/workflows/reusable-test-policy-rego.yml
+++ b/.github/workflows/reusable-test-policy-rego.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install opa
-        uses: kubewarden/github-actions/opa-installer@9bb758a49be7721e7862a6ae9c53f64766fc1215
+        uses: kubewarden/github-actions/opa-installer@fa781ccab6332172628173be64db32a1d0a877e4
       - name: Run unit tests
         working-directory: ${{ inputs.policy-working-dir }}
         run: make test

--- a/.github/workflows/reusable-test-policy-rust.yml
+++ b/.github/workflows/reusable-test-policy-rust.yml
@@ -53,11 +53,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@9bb758a49be7721e7862a6ae9c53f64766fc1215
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@fa781ccab6332172628173be64db32a1d0a877e4
       - name: Build and annotate policy
         with:
           generate-sbom: false
-        uses: kubewarden/github-actions/policy-build-rust@9bb758a49be7721e7862a6ae9c53f64766fc1215
+        uses: kubewarden/github-actions/policy-build-rust@fa781ccab6332172628173be64db32a1d0a877e4
       - name: Run e2e tests
         run: |
           make e2e-tests

--- a/attestation/action.yml
+++ b/attestation/action.yml
@@ -18,7 +18,7 @@ runs:
     - name: Install cosign
       uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
     - name: Install the crane command
-      uses: kubewarden/github-actions/crane-installer@9bb758a49be7721e7862a6ae9c53f64766fc1215
+      uses: kubewarden/github-actions/crane-installer@fa781ccab6332172628173be64db32a1d0a877e4
     - name: Login to GitHub Container Registry
       uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
       with:

--- a/policy-gh-action-dependencies/action.yml
+++ b/policy-gh-action-dependencies/action.yml
@@ -9,11 +9,11 @@ runs:
     - name: Install cosign
       uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
     - name: Install kwctl
-      uses: kubewarden/github-actions/kwctl-installer@9bb758a49be7721e7862a6ae9c53f64766fc1215
+      uses: kubewarden/github-actions/kwctl-installer@fa781ccab6332172628173be64db32a1d0a877e4
     - name: Install bats
       run: sudo apt install -y bats
       shell: bash
     - name: Install SBOM generator tool
-      uses: kubewarden/github-actions/syft-installer@9bb758a49be7721e7862a6ae9c53f64766fc1215
+      uses: kubewarden/github-actions/syft-installer@fa781ccab6332172628173be64db32a1d0a877e4
     - name: Install binaryen tool
-      uses: kubewarden/github-actions/binaryen-installer@9bb758a49be7721e7862a6ae9c53f64766fc1215
+      uses: kubewarden/github-actions/binaryen-installer@fa781ccab6332172628173be64db32a1d0a877e4

--- a/push-artifacthub/action.yml
+++ b/push-artifacthub/action.yml
@@ -12,7 +12,7 @@ runs:
   using: "composite"
   steps:
     - name: Install kwctl
-      uses: kubewarden/github-actions/kwctl-installer@9bb758a49be7721e7862a6ae9c53f64766fc1215
+      uses: kubewarden/github-actions/kwctl-installer@fa781ccab6332172628173be64db32a1d0a877e4
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:


### PR DESCRIPTION
## Description

Needed to consume kwctl 1.35 for go 1.26 support.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

To test this pull request, you can run the following commands:

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

## Checklist

- [ ] I have read and understood the [Kubewarden AI Policy](https://github.com/kubewarden/community/blob/main/AI_POLICY.md)
