### PR TITLE
feat(attestation): add namespace input for container image path

### DIFF
--- a/.github/workflows/reusable-release-policy-assemblyscript.yml
+++ b/.github/workflows/reusable-release-policy-assemblyscript.yml
@@ -19,7 +19,7 @@ jobs:
       NODE_VERSION: 14
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@9e24f3e522b32b838e1f066bd42995a438212e1d
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@fa41272f9c597dc2a2b35ac6a524aad669908b30
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -48,7 +48,7 @@ jobs:
       - name: Check that `io.kubewarden.policy.version` annotation is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: kubewarden/github-actions/check-policy-version@9e24f3e522b32b838e1f066bd42995a438212e1d
+        uses: kubewarden/github-actions/check-policy-version@fa41272f9c597dc2a2b35ac6a524aad669908b30
         with:
           expected-version: ${{ steps.calculate-version.outputs.version }}
       - name: Setup node
@@ -71,7 +71,7 @@ jobs:
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@9e24f3e522b32b838e1f066bd42995a438212e1d
+        uses: kubewarden/github-actions/policy-release@fa41272f9c597dc2a2b35ac6a524aad669908b30
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -88,4 +88,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@9e24f3e522b32b838e1f066bd42995a438212e1d
+        uses: kubewarden/github-actions/push-artifacthub@fa41272f9c597dc2a2b35ac6a524aad669908b30

--- a/.github/workflows/reusable-release-policy-go-wasi.yml
+++ b/.github/workflows/reusable-release-policy-go-wasi.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@9e24f3e522b32b838e1f066bd42995a438212e1d
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@fa41272f9c597dc2a2b35ac6a524aad669908b30
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -46,16 +46,16 @@ jobs:
       - name: Check that `io.kubewarden.policy.version` annotation is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: kubewarden/github-actions/check-policy-version@9e24f3e522b32b838e1f066bd42995a438212e1d
+        uses: kubewarden/github-actions/check-policy-version@fa41272f9c597dc2a2b35ac6a524aad669908b30
         with:
           expected-version: ${{ steps.calculate-version.outputs.version }}
       - name: Build and annotate policy
-        uses: kubewarden/github-actions/policy-build-go-wasi@9e24f3e522b32b838e1f066bd42995a438212e1d
+        uses: kubewarden/github-actions/policy-build-go-wasi@fa41272f9c597dc2a2b35ac6a524aad669908b30
       - name: Run e2e tests
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@9e24f3e522b32b838e1f066bd42995a438212e1d
+        uses: kubewarden/github-actions/policy-release@fa41272f9c597dc2a2b35ac6a524aad669908b30
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -71,4 +71,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@9e24f3e522b32b838e1f066bd42995a438212e1d
+        uses: kubewarden/github-actions/push-artifacthub@fa41272f9c597dc2a2b35ac6a524aad669908b30

--- a/.github/workflows/reusable-release-policy-go.yml
+++ b/.github/workflows/reusable-release-policy-go.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@9e24f3e522b32b838e1f066bd42995a438212e1d
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@fa41272f9c597dc2a2b35ac6a524aad669908b30
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -46,16 +46,16 @@ jobs:
       - name: Check that `io.kubewarden.policy.version` annotation is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: kubewarden/github-actions/check-policy-version@9e24f3e522b32b838e1f066bd42995a438212e1d
+        uses: kubewarden/github-actions/check-policy-version@fa41272f9c597dc2a2b35ac6a524aad669908b30
         with:
           expected-version: ${{ steps.calculate-version.outputs.version }}
       - name: Build and annotate policy
-        uses: kubewarden/github-actions/policy-build-tinygo@9e24f3e522b32b838e1f066bd42995a438212e1d
+        uses: kubewarden/github-actions/policy-build-tinygo@fa41272f9c597dc2a2b35ac6a524aad669908b30
       - name: Run e2e tests
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@9e24f3e522b32b838e1f066bd42995a438212e1d
+        uses: kubewarden/github-actions/policy-release@fa41272f9c597dc2a2b35ac6a524aad669908b30
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -71,4 +71,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@9e24f3e522b32b838e1f066bd42995a438212e1d
+        uses: kubewarden/github-actions/push-artifacthub@fa41272f9c597dc2a2b35ac6a524aad669908b30

--- a/.github/workflows/reusable-release-policy-rego.yml
+++ b/.github/workflows/reusable-release-policy-rego.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@9e24f3e522b32b838e1f066bd42995a438212e1d
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@fa41272f9c597dc2a2b35ac6a524aad669908b30
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -64,12 +64,12 @@ jobs:
       - name: Check that `io.kubewarden.policy.version` annotation is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: kubewarden/github-actions/check-policy-version@9e24f3e522b32b838e1f066bd42995a438212e1d
+        uses: kubewarden/github-actions/check-policy-version@fa41272f9c597dc2a2b35ac6a524aad669908b30
         with:
           expected-version: ${{ steps.calculate-version.outputs.version }}
           policy-working-dir: ${{ inputs.policy-working-dir }}
       - name: Install opa
-        uses: kubewarden/github-actions/opa-installer@9e24f3e522b32b838e1f066bd42995a438212e1d
+        uses: kubewarden/github-actions/opa-installer@fa41272f9c597dc2a2b35ac6a524aad669908b30
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Build policy
         working-directory: ${{ inputs.policy-working-dir }}
@@ -87,7 +87,7 @@ jobs:
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@9e24f3e522b32b838e1f066bd42995a438212e1d
+        uses: kubewarden/github-actions/policy-release@fa41272f9c597dc2a2b35ac6a524aad669908b30
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -105,6 +105,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@9e24f3e522b32b838e1f066bd42995a438212e1d
+        uses: kubewarden/github-actions/push-artifacthub@fa41272f9c597dc2a2b35ac6a524aad669908b30
         with:
           policy-working-dir: ${{ inputs.policy-working-dir }}

--- a/.github/workflows/reusable-release-policy-rust.yml
+++ b/.github/workflows/reusable-release-policy-rust.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@9e24f3e522b32b838e1f066bd42995a438212e1d
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@fa41272f9c597dc2a2b35ac6a524aad669908b30
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -46,16 +46,16 @@ jobs:
       - name: Check that `io.kubewarden.policy.version` annotation is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: kubewarden/github-actions/check-policy-version@9e24f3e522b32b838e1f066bd42995a438212e1d
+        uses: kubewarden/github-actions/check-policy-version@fa41272f9c597dc2a2b35ac6a524aad669908b30
         with:
           expected-version: ${{ steps.calculate-version.outputs.version }}
       - name: Build and annotate policy
-        uses: kubewarden/github-actions/policy-build-rust@9e24f3e522b32b838e1f066bd42995a438212e1d
+        uses: kubewarden/github-actions/policy-build-rust@fa41272f9c597dc2a2b35ac6a524aad669908b30
       - name: Run e2e tests
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@9e24f3e522b32b838e1f066bd42995a438212e1d
+        uses: kubewarden/github-actions/policy-release@fa41272f9c597dc2a2b35ac6a524aad669908b30
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -71,4 +71,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@9e24f3e522b32b838e1f066bd42995a438212e1d
+        uses: kubewarden/github-actions/push-artifacthub@fa41272f9c597dc2a2b35ac6a524aad669908b30

--- a/.github/workflows/reusable-release-policy-swift.yml
+++ b/.github/workflows/reusable-release-policy-swift.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@9e24f3e522b32b838e1f066bd42995a438212e1d
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@fa41272f9c597dc2a2b35ac6a524aad669908b30
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # until https://github.com/actions/checkout/pull/579 is released
@@ -46,7 +46,7 @@ jobs:
       - name: Check that `io.kubewarden.policy.version` annotation is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: kubewarden/github-actions/check-policy-version@9e24f3e522b32b838e1f066bd42995a438212e1d
+        uses: kubewarden/github-actions/check-policy-version@fa41272f9c597dc2a2b35ac6a524aad669908b30
         with:
           expected-version: ${{ steps.calculate-version.outputs.version }}
       - name: install wasm-strip
@@ -72,7 +72,7 @@ jobs:
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@9e24f3e522b32b838e1f066bd42995a438212e1d
+        uses: kubewarden/github-actions/policy-release@fa41272f9c597dc2a2b35ac6a524aad669908b30
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -88,4 +88,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@9e24f3e522b32b838e1f066bd42995a438212e1d
+        uses: kubewarden/github-actions/push-artifacthub@fa41272f9c597dc2a2b35ac6a524aad669908b30

--- a/.github/workflows/reusable-test-policy-go-wasi.yml
+++ b/.github/workflows/reusable-test-policy-go-wasi.yml
@@ -23,11 +23,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@9e24f3e522b32b838e1f066bd42995a438212e1d
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@fa41272f9c597dc2a2b35ac6a524aad669908b30
       - name: Build and annotate policy
         with:
           generate-sbom: false
-        uses: kubewarden/github-actions/policy-build-go-wasi@9e24f3e522b32b838e1f066bd42995a438212e1d
+        uses: kubewarden/github-actions/policy-build-go-wasi@fa41272f9c597dc2a2b35ac6a524aad669908b30
       - name: Run e2e tests
         run: make e2e-tests
 

--- a/.github/workflows/reusable-test-policy-go.yml
+++ b/.github/workflows/reusable-test-policy-go.yml
@@ -23,11 +23,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@9e24f3e522b32b838e1f066bd42995a438212e1d
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@fa41272f9c597dc2a2b35ac6a524aad669908b30
       - name: Build and annotate policy
         with:
           generate-sbom: false
-        uses: kubewarden/github-actions/policy-build-tinygo@9e24f3e522b32b838e1f066bd42995a438212e1d
+        uses: kubewarden/github-actions/policy-build-tinygo@fa41272f9c597dc2a2b35ac6a524aad669908b30
       - name: Run e2e tests
         run: make e2e-tests
 

--- a/.github/workflows/reusable-test-policy-rego.yml
+++ b/.github/workflows/reusable-test-policy-rego.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install opa
-        uses: kubewarden/github-actions/opa-installer@9e24f3e522b32b838e1f066bd42995a438212e1d
+        uses: kubewarden/github-actions/opa-installer@fa41272f9c597dc2a2b35ac6a524aad669908b30
       - name: Run unit tests
         working-directory: ${{ inputs.policy-working-dir }}
         run: make test

--- a/.github/workflows/reusable-test-policy-rust.yml
+++ b/.github/workflows/reusable-test-policy-rust.yml
@@ -53,11 +53,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@9e24f3e522b32b838e1f066bd42995a438212e1d
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@fa41272f9c597dc2a2b35ac6a524aad669908b30
       - name: Build and annotate policy
         with:
           generate-sbom: false
-        uses: kubewarden/github-actions/policy-build-rust@9e24f3e522b32b838e1f066bd42995a438212e1d
+        uses: kubewarden/github-actions/policy-build-rust@fa41272f9c597dc2a2b35ac6a524aad669908b30
       - name: Run e2e tests
         run: |
           make e2e-tests

--- a/attestation/action.yml
+++ b/attestation/action.yml
@@ -23,7 +23,7 @@ runs:
     - name: Install cosign
       uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
     - name: Install the crane command
-      uses: kubewarden/github-actions/crane-installer@9e24f3e522b32b838e1f066bd42995a438212e1d
+      uses: kubewarden/github-actions/crane-installer@fa41272f9c597dc2a2b35ac6a524aad669908b30
     - name: Login to GitHub Container Registry
       uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
       with:

--- a/attestation/action.yml
+++ b/attestation/action.yml
@@ -8,6 +8,11 @@ inputs:
   arch:
     description: architecture being processed
     required: true
+  namespace:
+    description: |
+      Path prefix for the container image name. The image becomes
+      ghcr.io/<owner>/<namespace>/<component>.
+    required: true
   github-token:
     description: |
       The GitHub token with permission to publish images to ghcr.
@@ -42,7 +47,7 @@ runs:
       shell: bash
       run: |
         set -e
-        DIGEST=$(crane manifest ghcr.io/${{ github.repository_owner }}/${{ inputs.component }}@${{ env.DIGEST }} \
+        DIGEST=$(crane manifest ghcr.io/${{ github.repository_owner }}/${{ inputs.namespace }}/${{ inputs.component }}@${{ env.DIGEST }} \
         | jq -r '.manifests[]
           | select(.annotations["vnd.docker.reference.type"] == "attestation-manifest")
           | .digest')
@@ -55,7 +60,7 @@ runs:
       shell: bash
       run: |
         set -e
-        DIGEST=$(crane manifest ghcr.io/${{ github.repository_owner }}/${{ inputs.component }}@${{ env.ATTESTATION_MANIFEST_DIGEST }} |
+        DIGEST=$(crane manifest ghcr.io/${{ github.repository_owner }}/${{ inputs.namespace }}/${{ inputs.component }}@${{ env.ATTESTATION_MANIFEST_DIGEST }} |
                     jq -r '.layers[]
                       | select(.annotations["in-toto.io/predicate-type"] == "https://slsa.dev/provenance/v1")
                       | .digest')
@@ -68,7 +73,7 @@ runs:
       shell: bash
       run: |
         set -e
-        DIGEST=$(crane manifest ghcr.io/${{ github.repository_owner }}/${{ inputs.component }}@${{ env.ATTESTATION_MANIFEST_DIGEST}} |  \
+        DIGEST=$(crane manifest ghcr.io/${{ github.repository_owner }}/${{ inputs.namespace }}/${{ inputs.component }}@${{ env.ATTESTATION_MANIFEST_DIGEST}} |  \
           jq -r '.layers
             | map(select(.annotations["in-toto.io/predicate-type"] == "https://spdx.dev/Document"))
             | map(.digest)
@@ -89,9 +94,9 @@ runs:
       shell: bash
       run: |
         set -e
-        crane blob ghcr.io/${{ github.repository_owner }}/${{ inputs.component }}@${{ env.PROVENANCE_DIGEST}} \
+        crane blob ghcr.io/${{ github.repository_owner }}/${{ inputs.namespace }}/${{ inputs.component }}@${{ env.PROVENANCE_DIGEST}} \
           > ${{ inputs.component }}-attestation-${{ inputs.arch }}-provenance.intoto.jsonl
-        crane blob ghcr.io/${{ github.repository_owner }}/${{ inputs.component }}@${{ env.SBOM_DIGEST}} \
+        crane blob ghcr.io/${{ github.repository_owner }}/${{ inputs.namespace }}/${{ inputs.component }}@${{ env.SBOM_DIGEST}} \
           > ${{ inputs.component }}-attestation-${{ inputs.arch }}-sbom.json
     - name: Sign provenance and SBOM files
       shell: bash

--- a/policy-gh-action-dependencies/action.yml
+++ b/policy-gh-action-dependencies/action.yml
@@ -9,11 +9,11 @@ runs:
     - name: Install cosign
       uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
     - name: Install kwctl
-      uses: kubewarden/github-actions/kwctl-installer@9e24f3e522b32b838e1f066bd42995a438212e1d
+      uses: kubewarden/github-actions/kwctl-installer@fa41272f9c597dc2a2b35ac6a524aad669908b30
     - name: Install bats
       run: sudo apt install -y bats
       shell: bash
     - name: Install SBOM generator tool
-      uses: kubewarden/github-actions/syft-installer@9e24f3e522b32b838e1f066bd42995a438212e1d
+      uses: kubewarden/github-actions/syft-installer@fa41272f9c597dc2a2b35ac6a524aad669908b30
     - name: Install binaryen tool
-      uses: kubewarden/github-actions/binaryen-installer@9e24f3e522b32b838e1f066bd42995a438212e1d
+      uses: kubewarden/github-actions/binaryen-installer@fa41272f9c597dc2a2b35ac6a524aad669908b30

--- a/push-artifacthub/action.yml
+++ b/push-artifacthub/action.yml
@@ -12,7 +12,7 @@ runs:
   using: "composite"
   steps:
     - name: Install kwctl
-      uses: kubewarden/github-actions/kwctl-installer@9e24f3e522b32b838e1f066bd42995a438212e1d
+      uses: kubewarden/github-actions/kwctl-installer@fa41272f9c597dc2a2b35ac6a524aad669908b30
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:


### PR DESCRIPTION
## Description

Add a mandatory 'namespace' input to the attestation action to allow callers to specify the container image namespace. This aligns with the pattern already used in container-build and merge-multiarch actions, enabling flexible namespace configuration without requiring multiple releases.
    
The namespace is used to construct the image path as: ghcr.io/<owner>/<namespace>/<component>

Part of https://github.com/kubewarden/adm-controller/issues/1657


