### PR TITLE
fix: Update kwctl-installer signature check to new repo name

### DIFF
--- a/.github/workflows/reusable-release-policy-assemblyscript.yml
+++ b/.github/workflows/reusable-release-policy-assemblyscript.yml
@@ -19,7 +19,7 @@ jobs:
       NODE_VERSION: 14
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@540e407be3b5eb379482bd9ea2a2de51a79a74cb
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@1a674c5c7f808bbe48765e5f9a01c6818a3642ac
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
@@ -48,7 +48,7 @@ jobs:
       - name: Check that `io.kubewarden.policy.version` annotation is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: kubewarden/github-actions/check-policy-version@540e407be3b5eb379482bd9ea2a2de51a79a74cb
+        uses: kubewarden/github-actions/check-policy-version@1a674c5c7f808bbe48765e5f9a01c6818a3642ac
         with:
           expected-version: ${{ steps.calculate-version.outputs.version }}
       - name: Setup node
@@ -74,7 +74,7 @@ jobs:
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@540e407be3b5eb379482bd9ea2a2de51a79a74cb
+        uses: kubewarden/github-actions/policy-release@1a674c5c7f808bbe48765e5f9a01c6818a3642ac
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -91,4 +91,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@540e407be3b5eb379482bd9ea2a2de51a79a74cb
+        uses: kubewarden/github-actions/push-artifacthub@1a674c5c7f808bbe48765e5f9a01c6818a3642ac

--- a/.github/workflows/reusable-release-policy-go-wasi.yml
+++ b/.github/workflows/reusable-release-policy-go-wasi.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@540e407be3b5eb379482bd9ea2a2de51a79a74cb
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@1a674c5c7f808bbe48765e5f9a01c6818a3642ac
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
@@ -46,16 +46,16 @@ jobs:
       - name: Check that `io.kubewarden.policy.version` annotation is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: kubewarden/github-actions/check-policy-version@540e407be3b5eb379482bd9ea2a2de51a79a74cb
+        uses: kubewarden/github-actions/check-policy-version@1a674c5c7f808bbe48765e5f9a01c6818a3642ac
         with:
           expected-version: ${{ steps.calculate-version.outputs.version }}
       - name: Build and annotate policy
-        uses: kubewarden/github-actions/policy-build-go-wasi@540e407be3b5eb379482bd9ea2a2de51a79a74cb
+        uses: kubewarden/github-actions/policy-build-go-wasi@1a674c5c7f808bbe48765e5f9a01c6818a3642ac
       - name: Run e2e tests
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@540e407be3b5eb379482bd9ea2a2de51a79a74cb
+        uses: kubewarden/github-actions/policy-release@1a674c5c7f808bbe48765e5f9a01c6818a3642ac
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -71,4 +71,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@540e407be3b5eb379482bd9ea2a2de51a79a74cb
+        uses: kubewarden/github-actions/push-artifacthub@1a674c5c7f808bbe48765e5f9a01c6818a3642ac

--- a/.github/workflows/reusable-release-policy-go.yml
+++ b/.github/workflows/reusable-release-policy-go.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@540e407be3b5eb379482bd9ea2a2de51a79a74cb
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@1a674c5c7f808bbe48765e5f9a01c6818a3642ac
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
@@ -46,16 +46,16 @@ jobs:
       - name: Check that `io.kubewarden.policy.version` annotation is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: kubewarden/github-actions/check-policy-version@540e407be3b5eb379482bd9ea2a2de51a79a74cb
+        uses: kubewarden/github-actions/check-policy-version@1a674c5c7f808bbe48765e5f9a01c6818a3642ac
         with:
           expected-version: ${{ steps.calculate-version.outputs.version }}
       - name: Build and annotate policy
-        uses: kubewarden/github-actions/policy-build-tinygo@540e407be3b5eb379482bd9ea2a2de51a79a74cb
+        uses: kubewarden/github-actions/policy-build-tinygo@1a674c5c7f808bbe48765e5f9a01c6818a3642ac
       - name: Run e2e tests
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@540e407be3b5eb379482bd9ea2a2de51a79a74cb
+        uses: kubewarden/github-actions/policy-release@1a674c5c7f808bbe48765e5f9a01c6818a3642ac
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -71,4 +71,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@540e407be3b5eb379482bd9ea2a2de51a79a74cb
+        uses: kubewarden/github-actions/push-artifacthub@1a674c5c7f808bbe48765e5f9a01c6818a3642ac

--- a/.github/workflows/reusable-release-policy-rego.yml
+++ b/.github/workflows/reusable-release-policy-rego.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@540e407be3b5eb379482bd9ea2a2de51a79a74cb
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@1a674c5c7f808bbe48765e5f9a01c6818a3642ac
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
@@ -64,12 +64,12 @@ jobs:
       - name: Check that `io.kubewarden.policy.version` annotation is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: kubewarden/github-actions/check-policy-version@540e407be3b5eb379482bd9ea2a2de51a79a74cb
+        uses: kubewarden/github-actions/check-policy-version@1a674c5c7f808bbe48765e5f9a01c6818a3642ac
         with:
           expected-version: ${{ steps.calculate-version.outputs.version }}
           policy-working-dir: ${{ inputs.policy-working-dir }}
       - name: Install opa
-        uses: kubewarden/github-actions/opa-installer@540e407be3b5eb379482bd9ea2a2de51a79a74cb
+        uses: kubewarden/github-actions/opa-installer@1a674c5c7f808bbe48765e5f9a01c6818a3642ac
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
@@ -90,7 +90,7 @@ jobs:
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@540e407be3b5eb379482bd9ea2a2de51a79a74cb
+        uses: kubewarden/github-actions/policy-release@1a674c5c7f808bbe48765e5f9a01c6818a3642ac
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -108,6 +108,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@540e407be3b5eb379482bd9ea2a2de51a79a74cb
+        uses: kubewarden/github-actions/push-artifacthub@1a674c5c7f808bbe48765e5f9a01c6818a3642ac
         with:
           policy-working-dir: ${{ inputs.policy-working-dir }}

--- a/.github/workflows/reusable-release-policy-rust.yml
+++ b/.github/workflows/reusable-release-policy-rust.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@540e407be3b5eb379482bd9ea2a2de51a79a74cb
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@1a674c5c7f808bbe48765e5f9a01c6818a3642ac
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
@@ -46,16 +46,16 @@ jobs:
       - name: Check that `io.kubewarden.policy.version` annotation is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: kubewarden/github-actions/check-policy-version@540e407be3b5eb379482bd9ea2a2de51a79a74cb
+        uses: kubewarden/github-actions/check-policy-version@1a674c5c7f808bbe48765e5f9a01c6818a3642ac
         with:
           expected-version: ${{ steps.calculate-version.outputs.version }}
       - name: Build and annotate policy
-        uses: kubewarden/github-actions/policy-build-rust@540e407be3b5eb379482bd9ea2a2de51a79a74cb
+        uses: kubewarden/github-actions/policy-build-rust@1a674c5c7f808bbe48765e5f9a01c6818a3642ac
       - name: Run e2e tests
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@540e407be3b5eb379482bd9ea2a2de51a79a74cb
+        uses: kubewarden/github-actions/policy-release@1a674c5c7f808bbe48765e5f9a01c6818a3642ac
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -71,4 +71,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@540e407be3b5eb379482bd9ea2a2de51a79a74cb
+        uses: kubewarden/github-actions/push-artifacthub@1a674c5c7f808bbe48765e5f9a01c6818a3642ac

--- a/.github/workflows/reusable-release-policy-swift.yml
+++ b/.github/workflows/reusable-release-policy-swift.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@540e407be3b5eb379482bd9ea2a2de51a79a74cb
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@1a674c5c7f808bbe48765e5f9a01c6818a3642ac
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
@@ -46,7 +46,7 @@ jobs:
       - name: Check that `io.kubewarden.policy.version` annotation is up-to-date
         # skip when releasing :latest from main, versions will not match
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: kubewarden/github-actions/check-policy-version@540e407be3b5eb379482bd9ea2a2de51a79a74cb
+        uses: kubewarden/github-actions/check-policy-version@1a674c5c7f808bbe48765e5f9a01c6818a3642ac
         with:
           expected-version: ${{ steps.calculate-version.outputs.version }}
       - name: install wasm-strip
@@ -72,7 +72,7 @@ jobs:
         run: |
           make e2e-tests
       - name: Release
-        uses: kubewarden/github-actions/policy-release@540e407be3b5eb379482bd9ea2a2de51a79a74cb
+        uses: kubewarden/github-actions/policy-release@1a674c5c7f808bbe48765e5f9a01c6818a3642ac
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           oci-target: ${{ inputs.oci-target }}
@@ -88,4 +88,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Push artifacthub files to artifacthub branch
-        uses: kubewarden/github-actions/push-artifacthub@540e407be3b5eb379482bd9ea2a2de51a79a74cb
+        uses: kubewarden/github-actions/push-artifacthub@1a674c5c7f808bbe48765e5f9a01c6818a3642ac

--- a/.github/workflows/reusable-test-policy-go-wasi.yml
+++ b/.github/workflows/reusable-test-policy-go-wasi.yml
@@ -23,11 +23,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@540e407be3b5eb379482bd9ea2a2de51a79a74cb
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@1a674c5c7f808bbe48765e5f9a01c6818a3642ac
       - name: Build and annotate policy
         with:
           generate-sbom: false
-        uses: kubewarden/github-actions/policy-build-go-wasi@540e407be3b5eb379482bd9ea2a2de51a79a74cb
+        uses: kubewarden/github-actions/policy-build-go-wasi@1a674c5c7f808bbe48765e5f9a01c6818a3642ac
       - name: Run e2e tests
         run: make e2e-tests
 

--- a/.github/workflows/reusable-test-policy-go.yml
+++ b/.github/workflows/reusable-test-policy-go.yml
@@ -23,11 +23,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@540e407be3b5eb379482bd9ea2a2de51a79a74cb
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@1a674c5c7f808bbe48765e5f9a01c6818a3642ac
       - name: Build and annotate policy
         with:
           generate-sbom: false
-        uses: kubewarden/github-actions/policy-build-tinygo@540e407be3b5eb379482bd9ea2a2de51a79a74cb
+        uses: kubewarden/github-actions/policy-build-tinygo@1a674c5c7f808bbe48765e5f9a01c6818a3642ac
       - name: Run e2e tests
         run: make e2e-tests
 

--- a/.github/workflows/reusable-test-policy-rego.yml
+++ b/.github/workflows/reusable-test-policy-rego.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install opa
-        uses: kubewarden/github-actions/opa-installer@540e407be3b5eb379482bd9ea2a2de51a79a74cb
+        uses: kubewarden/github-actions/opa-installer@1a674c5c7f808bbe48765e5f9a01c6818a3642ac
       - name: Run unit tests
         working-directory: ${{ inputs.policy-working-dir }}
         run: make test

--- a/.github/workflows/reusable-test-policy-rust.yml
+++ b/.github/workflows/reusable-test-policy-rust.yml
@@ -53,11 +53,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install dependencies
-        uses: kubewarden/github-actions/policy-gh-action-dependencies@540e407be3b5eb379482bd9ea2a2de51a79a74cb
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@1a674c5c7f808bbe48765e5f9a01c6818a3642ac
       - name: Build and annotate policy
         with:
           generate-sbom: false
-        uses: kubewarden/github-actions/policy-build-rust@540e407be3b5eb379482bd9ea2a2de51a79a74cb
+        uses: kubewarden/github-actions/policy-build-rust@1a674c5c7f808bbe48765e5f9a01c6818a3642ac
       - name: Run e2e tests
         run: |
           make e2e-tests

--- a/attestation/action.yml
+++ b/attestation/action.yml
@@ -23,7 +23,7 @@ runs:
     - name: Install cosign
       uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
     - name: Install the crane command
-      uses: kubewarden/github-actions/crane-installer@540e407be3b5eb379482bd9ea2a2de51a79a74cb
+      uses: kubewarden/github-actions/crane-installer@1a674c5c7f808bbe48765e5f9a01c6818a3642ac
     - name: Login to GitHub Container Registry
       uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
       with:

--- a/attestation/action.yml
+++ b/attestation/action.yml
@@ -3,7 +3,7 @@ description: extract and sign provenance and SBOM files
 inputs:
   component:
     description: |
-      The component name (e.g., policy-server, kubewarden-controller, audit-scanner)
+      The component name (e.g., policy-server, controller, audit-scanner)
     required: true
   arch:
     description: architecture being processed

--- a/container-build/action.yml
+++ b/container-build/action.yml
@@ -6,7 +6,7 @@ inputs:
     default: digest-
   component:
     description: |
-      The component name (e.g., policy-server, kubewarden-controller, audit-scanner)
+      The component name (e.g., policy-server, controller, audit-scanner)
     required: true
   arch:
     description: |

--- a/kwctl-installer/README.md
+++ b/kwctl-installer/README.md
@@ -15,5 +15,5 @@ The downloaded zip contains both the `kwctl` binary and its
 * `KWCTL_VERSION`: (**optional**) the version of kwctl to be downloaded.
   Accepts a specific semver tag (e.g. `v1.34.2`) or the special value
   `latest`, which resolves to the most recent release in
-  `kubewarden/kubewarden-controller` (including `rc`, `alpha`, and `beta`
+  `kubewarden/adm-controller` (including `rc`, `alpha`, and `beta`
   pre-releases).

--- a/kwctl-installer/action.yml
+++ b/kwctl-installer/action.yml
@@ -23,7 +23,7 @@ runs:
         KWCTL_VERSION="${{ inputs.kwctl-version }}"
 
         if [[ "$KWCTL_VERSION" == "latest" ]]; then
-          KWCTL_VERSION=$(gh release list --repo kubewarden/kubewarden-controller --exclude-drafts --limit 1 --json tagName --jq '.[0].tagName')
+          KWCTL_VERSION=$(gh release list --repo kubewarden/adm-controller --exclude-drafts --limit 1 --json tagName --jq '.[0].tagName')
           echo "Resolved latest to: $KWCTL_VERSION"
         fi
 
@@ -44,13 +44,13 @@ runs:
         BUNDLE_FILE=$INSTALL_DIR/$ASSET.bundle.sigstore
 
         mkdir -p $INSTALL_DIR
-        curl -fsSL https://github.com/kubewarden/kubewarden-controller/releases/download/${KWCTL_VERSION}/${ASSET}.zip -o $ZIP_FILE
+        curl -fsSL https://github.com/kubewarden/adm-controller/releases/download/${KWCTL_VERSION}/${ASSET}.zip -o $ZIP_FILE
         unzip -o $ZIP_FILE -d $INSTALL_DIR
         rm $ZIP_FILE
 
         cosign verify-blob \
           --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
-          --certificate-identity="https://github.com/kubewarden/kubewarden-controller/.github/workflows/build-kwctl.yml@refs/tags/${KWCTL_VERSION}" \
+          --certificate-identity="https://github.com/kubewarden/adm-controller/.github/workflows/build-kwctl.yml@refs/tags/${KWCTL_VERSION}" \
           --bundle $BUNDLE_FILE \
           $INSTALL_DIR/$ASSET
         rm $BUNDLE_FILE

--- a/merge-multiarch/action.yml
+++ b/merge-multiarch/action.yml
@@ -6,7 +6,7 @@ inputs:
     default: digest-
   component:
     description: |
-      The component name (e.g., policy-server, kubewarden-controller, audit-scanner)
+      The component name (e.g., policy-server, controller, audit-scanner)
     required: true
   tag:
     description: |

--- a/policy-gh-action-dependencies/action.yml
+++ b/policy-gh-action-dependencies/action.yml
@@ -9,11 +9,11 @@ runs:
     - name: Install cosign
       uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
     - name: Install kwctl
-      uses: kubewarden/github-actions/kwctl-installer@540e407be3b5eb379482bd9ea2a2de51a79a74cb
+      uses: kubewarden/github-actions/kwctl-installer@1a674c5c7f808bbe48765e5f9a01c6818a3642ac
     - name: Install bats
       run: sudo apt install -y bats
       shell: bash
     - name: Install SBOM generator tool
-      uses: kubewarden/github-actions/syft-installer@540e407be3b5eb379482bd9ea2a2de51a79a74cb
+      uses: kubewarden/github-actions/syft-installer@1a674c5c7f808bbe48765e5f9a01c6818a3642ac
     - name: Install binaryen tool
-      uses: kubewarden/github-actions/binaryen-installer@540e407be3b5eb379482bd9ea2a2de51a79a74cb
+      uses: kubewarden/github-actions/binaryen-installer@1a674c5c7f808bbe48765e5f9a01c6818a3642ac

--- a/push-artifacthub/action.yml
+++ b/push-artifacthub/action.yml
@@ -12,7 +12,7 @@ runs:
   using: "composite"
   steps:
     - name: Install kwctl
-      uses: kubewarden/github-actions/kwctl-installer@540e407be3b5eb379482bd9ea2a2de51a79a74cb
+      uses: kubewarden/github-actions/kwctl-installer@1a674c5c7f808bbe48765e5f9a01c6818a3642ac
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
If calling kwctl-installer with `version: latest`, we will download the new `1.36.0-alpha1` which is signed differently. Update the signature OIDC check.

See failure in https://github.com/kubewarden/adm-controller/actions/runs/25378283664/job/74568417821?pr=1705#step:5:340
<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

Bump shasums for release.

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Untested.


<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

## Checklist

- [ ] I have read and understood the [Kubewarden AI Policy](https://github.com/kubewarden/community/blob/main/AI_POLICY.md)
