### PR TITLE
feat(renovate): run go mod tidy after Go module updates

### DIFF
--- a/renovate-config/default.json
+++ b/renovate-config/default.json
@@ -11,6 +11,9 @@
     "enabled": true,
     "automerge": true
   },
+  "postUpdateOptions": [
+    "gomodTidy"
+  ],
   "packageRules": [
     {
       "_comment": "bundle dependencies updates together",


### PR DESCRIPTION
## Description

Enable renovate's `gomodTidy` post-update option to reconcile `go.sum` after Go module bumps. 
By default, renovate edits `go.mod` but not `go.sum`. 

When a bump pulls in new transitive deps (e.g. a k8s minor), the PR lands with `go.sum` missing checksums, and anything that loads packages in readonly mode (`go build`, `govulncheck`) fails with `missing go.sum entry`.

Example:  https://github.com/kubewarden/sbomscanner/actions/runs/26019433254
