### PR TITLE
ci(renovate): add 7-day cooldown for dependency updates

### DIFF
--- a/renovate-config/default.json
+++ b/renovate-config/default.json
@@ -35,5 +35,9 @@
   "prHourlyLimit": 0,
   "prConcurrentLimit": 0,
   "semanticCommits": "enabled",
-  "semanticCommitType": "build"
+  "semanticCommitType": "build",
+  "minimumReleaseAge": "7 days",
+  "vulnerabilityAlerts": {
+    "minimumReleaseAge": "0 days"
+  }
 }

--- a/renovate-config/policies.json
+++ b/renovate-config/policies.json
@@ -34,5 +34,9 @@
   "prHourlyLimit": 0,
   "prConcurrentLimit": 0,
   "semanticCommits": "enabled",
-  "semanticCommitType": "chore"
+  "semanticCommitType": "chore",
+  "minimumReleaseAge": "7 days",
+  "vulnerabilityAlerts": {
+    "minimumReleaseAge": "0 days"
+  }
 }


### PR DESCRIPTION
## Description

Applies a 1-week cooldown to the common Renovate config, except for security/vulnerability updates.